### PR TITLE
[fix][broker] Fix ReplicationDispatch update

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ResourceGroupsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/ResourceGroupsBase.java
@@ -75,7 +75,12 @@ public abstract class ResourceGroupsBase extends AdminResource {
             if (rgConfig.getDispatchRateInBytes() != null) {
                 resourceGroup.setDispatchRateInBytes(rgConfig.getDispatchRateInBytes());
             }
-
+            if (rgConfig.getReplicationDispatchRateInBytes() != null) {
+                resourceGroup.setReplicationDispatchRateInBytes(rgConfig.getReplicationDispatchRateInBytes());
+            }
+            if (rgConfig.getReplicationDispatchRateInMsgs() != null) {
+                resourceGroup.setReplicationDispatchRateInMsgs(rgConfig.getReplicationDispatchRateInMsgs());
+            }
             // write back the new ResourceGroup config.
             resourceGroupResources().updateResourceGroup(rgName, r -> resourceGroup);
             log.info("[{}] Successfully updated the ResourceGroup {}", clientAppId(), rgName);
@@ -96,6 +101,10 @@ public abstract class ResourceGroupsBase extends AdminResource {
                 ? -1 : rgConfig.getDispatchRateInMsgs());
         rgConfig.setDispatchRateInBytes(rgConfig.getDispatchRateInBytes() == null
                 ? -1 : rgConfig.getDispatchRateInBytes());
+        rgConfig.setReplicationDispatchRateInBytes(rgConfig.getReplicationDispatchRateInBytes() == null
+                ? -1 : rgConfig.getReplicationDispatchRateInBytes());
+        rgConfig.setReplicationDispatchRateInMsgs(rgConfig.getReplicationDispatchRateInMsgs() == null
+                ? -1 : rgConfig.getReplicationDispatchRateInMsgs());
         try {
             resourceGroupResources().createResourceGroup(rgName, rgConfig);
             log.info("[{}] Created ResourceGroup {}", clientAppId(), rgName);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminResourceGroupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminResourceGroupTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.admin;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
@@ -137,5 +138,31 @@ public class AdminResourceGroupTest extends BrokerTestBase {
                     .getTopicResourceGroup(topicName);
             assertNull(rg);
         });
+    }
+
+    @Test
+    public void testUpdateResourceGroup() throws PulsarAdminException {
+        String resourceGroupName = "rg-" + UUID.randomUUID();
+        ResourceGroup resourceGroup = new ResourceGroup();
+        resourceGroup.setPublishRateInMsgs(1000);
+        resourceGroup.setPublishRateInBytes(100000L);
+        resourceGroup.setDispatchRateInMsgs(2000);
+        resourceGroup.setDispatchRateInBytes(200000L);
+        resourceGroup.setReplicationDispatchRateInMsgs(10L);
+        resourceGroup.setReplicationDispatchRateInBytes(20L);
+
+        admin.resourcegroups().createResourceGroup(resourceGroupName, resourceGroup);
+        ResourceGroup got = admin.resourcegroups().getResourceGroup(resourceGroupName);
+        assertEquals(got, resourceGroup);
+
+        resourceGroup.setReplicationDispatchRateInMsgs(11L);
+        resourceGroup.setReplicationDispatchRateInBytes(29L);
+        admin.resourcegroups().updateResourceGroup(resourceGroupName, resourceGroup);
+        got = admin.resourcegroups().getResourceGroup(resourceGroupName);
+        assertEquals(got, resourceGroup);
+
+        admin.resourcegroups().deleteResourceGroup(resourceGroupName);
+        assertThrows(PulsarAdminException.NotFoundException.class,
+                () -> admin.resourcegroups().getResourceGroup(resourceGroupName));
     }
 }


### PR DESCRIPTION
### Motivation

Admin updates the `replicationDispatchRateInMsgs` and `replicationDispatchRateInBytes` values of the ResourceGroup, which won't be changed in the metadata store.