### PR TITLE
[fix][sec] Upgrade vertx to 3.9.16

### DIFF
--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -520,11 +520,11 @@ The Apache Software License, Version 2.0
   * JCTools - Java Concurrency Tools for the JVM
     - org.jctools-jctools-core-2.1.2.jar
   * Vertx
-    - io.vertx-vertx-auth-common-3.9.8.jar
-    - io.vertx-vertx-bridge-common-3.9.8.jar
-    - io.vertx-vertx-core-3.9.8.jar
-    - io.vertx-vertx-web-3.9.8.jar
-    - io.vertx-vertx-web-common-3.9.8.jar
+    - io.vertx-vertx-auth-common-3.9.16.jar
+    - io.vertx-vertx-bridge-common-3.9.16.jar
+    - io.vertx-vertx-core-3.9.16.jar
+    - io.vertx-vertx-web-3.9.16.jar
+    - io.vertx-vertx-web-common-3.9.16.jar
   * Apache ZooKeeper
     - org.apache.zookeeper-zookeeper-3.9.2.jar
     - org.apache.zookeeper-zookeeper-jute-3.9.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@ flexible messaging model and an intuitive client API.</description>
     <jersey.version>2.34</jersey.version>
     <athenz.version>1.10.50</athenz.version>
     <prometheus.version>0.5.0</prometheus.version>
-    <vertx.version>3.9.8</vertx.version>
+    <vertx.version>3.9.16</vertx.version>
     <rocksdb.version>6.29.4.1</rocksdb.version>
     <slf4j.version>1.7.32</slf4j.version>
     <commons.collections.version>3.2.2</commons.collections.version>


### PR DESCRIPTION
### Motivation

Fix CVE.

### Modifications

- Upgrade vertx from 3.9.8 to 3.9.16.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->