### PR TITLE
[feat][broker] Support configuring replicator rate limiter per cluster

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -1532,11 +1532,12 @@ public abstract class NamespacesBase extends AdminResource {
         return policies.clusterSubscribeRate.get(pulsar().getConfiguration().getClusterName());
     }
 
-    protected void internalRemoveReplicatorDispatchRate() {
+    protected void internalRemoveReplicatorDispatchRate(String cluster) {
         validateSuperUserAccess();
         try {
             updatePolicies(namespaceName, policies -> {
-                policies.replicatorDispatchRate.remove(pulsar().getConfiguration().getClusterName());
+                policies.replicatorDispatchRate.remove(
+                        StringUtils.isNotEmpty(cluster) ? cluster : pulsar().getConfiguration().getClusterName());
                 return policies;
             });
             log.info("[{}] Successfully delete the replicatorDispatchRate for cluster on namespace {}", clientAppId(),
@@ -1548,12 +1549,14 @@ public abstract class NamespacesBase extends AdminResource {
         }
     }
 
-    protected void internalSetReplicatorDispatchRate(DispatchRateImpl dispatchRate) {
+    protected void internalSetReplicatorDispatchRate(String cluster, DispatchRateImpl dispatchRate) {
         validateSuperUserAccess();
         log.info("[{}] Set namespace replicator dispatch-rate {}/{}", clientAppId(), namespaceName, dispatchRate);
         try {
             updatePolicies(namespaceName, policies -> {
-                policies.replicatorDispatchRate.put(pulsar().getConfiguration().getClusterName(), dispatchRate);
+                policies.replicatorDispatchRate.put(
+                        StringUtils.isNotEmpty(cluster) ? cluster : pulsar().getConfiguration().getClusterName(),
+                        dispatchRate);
                 return policies;
             });
             log.info("[{}] Successfully updated the replicatorDispatchRate for cluster on namespace {}", clientAppId(),
@@ -1565,11 +1568,12 @@ public abstract class NamespacesBase extends AdminResource {
         }
     }
 
-    protected DispatchRate internalGetReplicatorDispatchRate() {
+    protected DispatchRate internalGetReplicatorDispatchRate(String cluster) {
         validateNamespacePolicyOperation(namespaceName, PolicyName.REPLICATION_RATE, PolicyOperation.READ);
 
         Policies policies = getNamespacePolicies(namespaceName);
-        return policies.replicatorDispatchRate.get(pulsar().getConfiguration().getClusterName());
+        return policies.replicatorDispatchRate.get(
+                StringUtils.isNotEmpty(cluster) ? cluster : pulsar().getConfiguration().getClusterName());
     }
 
     protected void internalSetBacklogQuota(BacklogQuotaType backlogQuotaType, BacklogQuota backlogQuota) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -3597,25 +3597,64 @@ public class PersistentTopicsBase extends AdminResource {
             });
     }
 
-    protected CompletableFuture<DispatchRateImpl> internalGetReplicatorDispatchRate(boolean applied, boolean isGlobal) {
+    protected CompletableFuture<DispatchRateImpl> internalGetReplicatorDispatchRate(String cluster, boolean applied,
+                                                                                    boolean isGlobal) {
         return getTopicPoliciesAsyncWithRetry(topicName, isGlobal)
-            .thenApply(op -> op.map(TopicPolicies::getReplicatorDispatchRate)
-                .orElseGet(() -> {
-                    if (applied) {
-                        DispatchRateImpl namespacePolicy = getNamespacePolicies(namespaceName)
-                                .replicatorDispatchRate.get(pulsar().getConfiguration().getClusterName());
-                        return namespacePolicy == null ? replicatorDispatchRate() : namespacePolicy;
+                .thenApply(op -> op.map(n -> {
+                    // Prioritize getting the dispatch rate from the replicatorDispatchRateMap if a specific cluster
+                    // is provided.
+                    // If the cluster is empty, it means the user has not explicitly set a rate for a particular
+                    // cluster,
+                    // so we still attempt to retrieve the value from the replicatorDispatchRateMap using the current
+                    // cluster.
+                    // If `applied` is true, we also need to consider the default cluster rate and finally fallback
+                    // to `getReplicatorDispatchRate()` for backward compatibility.
+                    if (StringUtils.isNotEmpty(cluster)) {
+                        DispatchRateImpl dispatchRate = n.getReplicatorDispatchRateMap().get(cluster);
+                        if (dispatchRate != null) {
+                            return dispatchRate;
+                        }
+                    }
+
+                    if (applied || StringUtils.isEmpty(cluster)) {
+                        DispatchRateImpl dispatchRate =
+                                n.getReplicatorDispatchRateMap().get(pulsar().getConfiguration().getClusterName());
+                        if (dispatchRate != null) {
+                            return dispatchRate;
+                        }
+                        // Backward compatibility.
+                        return n.getReplicatorDispatchRate();
                     }
                     return null;
+                }).orElseGet(() -> {
+                    if (!applied) {
+                        return null;
+                    }
+                    Map<String, DispatchRateImpl> replicatorDispatchRate =
+                            getNamespacePolicies(namespaceName).replicatorDispatchRate;
+                    DispatchRateImpl namespacePolicy = replicatorDispatchRate.getOrDefault(cluster,
+                            replicatorDispatchRate.get(pulsar().getConfiguration().getClusterName()));
+                    return namespacePolicy == null ? replicatorDispatchRate() : namespacePolicy;
                 }));
     }
 
-    protected CompletableFuture<Void> internalSetReplicatorDispatchRate(DispatchRateImpl dispatchRate,
+    protected CompletableFuture<Void> internalSetReplicatorDispatchRate(String cluster, DispatchRateImpl dispatchRate,
                                                                         boolean isGlobal) {
         return getTopicPoliciesAsyncWithRetry(topicName, isGlobal)
             .thenCompose(op -> {
                 TopicPolicies topicPolicies = op.orElseGet(TopicPolicies::new);
-                topicPolicies.setReplicatorDispatchRate(dispatchRate);
+                boolean usingDefaultCluster = StringUtils.isEmpty(cluster);
+                if (dispatchRate == null) {
+                    topicPolicies.getReplicatorDispatchRateMap()
+                            .remove(usingDefaultCluster ? pulsar().getConfiguration().getClusterName() : cluster);
+                } else {
+                    topicPolicies.getReplicatorDispatchRateMap()
+                            .put(usingDefaultCluster ? pulsar().getConfiguration().getClusterName() : cluster,
+                                    dispatchRate);
+                }
+                if (usingDefaultCluster) {
+                    topicPolicies.setReplicatorDispatchRate(dispatchRate);
+                }
                 topicPolicies.setIsGlobal(isGlobal);
                 return pulsar().getTopicPoliciesService().updateTopicPoliciesAsync(topicName, topicPolicies);
             });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -772,7 +772,7 @@ public class Namespaces extends NamespacesBase {
                                                   @PathParam("namespace") String namespace,
                                                   @QueryParam("cluster") String queryCluster) {
         validateNamespaceName(tenant, cluster, namespace);
-        return internalGetReplicatorDispatchRate(cluster);
+        return internalGetReplicatorDispatchRate(queryCluster);
     }
 
     @GET

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -753,10 +753,11 @@ public class Namespaces extends NamespacesBase {
     public void setReplicatorDispatchRate(
             @PathParam("tenant") String tenant,
             @PathParam("cluster") String cluster, @PathParam("namespace") String namespace,
+            @QueryParam("cluster") String queryCluster,
             @ApiParam(value = "Replicator dispatch rate for all topics of the specified namespace")
                     DispatchRateImpl dispatchRate) {
         validateNamespaceName(tenant, cluster, namespace);
-        internalSetReplicatorDispatchRate(dispatchRate);
+        internalSetReplicatorDispatchRate(queryCluster, dispatchRate);
     }
 
     @GET
@@ -768,9 +769,10 @@ public class Namespaces extends NamespacesBase {
         @ApiResponse(code = 404, message = "Namespace does not exist") })
     public DispatchRate getReplicatorDispatchRate(@PathParam("tenant") String tenant,
                                                     @PathParam("cluster") String cluster,
-                                                    @PathParam("namespace") String namespace) {
+                                                  @PathParam("namespace") String namespace,
+                                                  @QueryParam("cluster") String queryCluster) {
         validateNamespaceName(tenant, cluster, namespace);
-        return internalGetReplicatorDispatchRate();
+        return internalGetReplicatorDispatchRate(cluster);
     }
 
     @GET

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -717,9 +717,11 @@ public class Namespaces extends NamespacesBase {
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission")})
     public void removeReplicatorDispatchRate(
             @PathParam("tenant") String tenant,
-            @PathParam("namespace") String namespace) {
+            @PathParam("namespace") String namespace,
+            @QueryParam("cluster") String cluster
+    ) {
         validateNamespaceName(tenant, namespace);
-        internalRemoveReplicatorDispatchRate();
+        internalRemoveReplicatorDispatchRate(cluster);
     }
 
     @POST
@@ -727,11 +729,12 @@ public class Namespaces extends NamespacesBase {
     @ApiOperation(value = "Set replicator dispatch-rate throttling for all topics of the namespace")
     @ApiResponses(value = {@ApiResponse(code = 403, message = "Don't have admin permission")})
     public void setReplicatorDispatchRate(@PathParam("tenant") String tenant,
-                                          @PathParam("namespace") String namespace, @ApiParam(value =
+                                          @PathParam("namespace") String namespace,
+                                          @QueryParam("cluster") String cluster, @ApiParam(value =
             "Replicator dispatch rate for all topics of the specified namespace")
                                                       DispatchRateImpl dispatchRate) {
         validateNamespaceName(tenant, namespace);
-        internalSetReplicatorDispatchRate(dispatchRate);
+        internalSetReplicatorDispatchRate(cluster, dispatchRate);
     }
 
     @GET
@@ -742,9 +745,11 @@ public class Namespaces extends NamespacesBase {
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
         @ApiResponse(code = 404, message = "Namespace does not exist") })
     public DispatchRate getReplicatorDispatchRate(@PathParam("tenant") String tenant,
-                                                    @PathParam("namespace") String namespace) {
+                                                    @PathParam("namespace") String namespace,
+                                                    @QueryParam("cluster") String cluster
+                                                  ) {
         validateNamespaceName(tenant, namespace);
-        return internalGetReplicatorDispatchRate();
+        return internalGetReplicatorDispatchRate(cluster);
     }
 
     @GET

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -2531,11 +2531,12 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("isGlobal") @DefaultValue("false") boolean isGlobal,
             @QueryParam("applied") @DefaultValue("false") boolean applied,
             @ApiParam(value = "Whether leader broker redirected this call to this broker. For internal use.")
-            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
+            @QueryParam("cluster") String cluster) {
         validateTopicName(tenant, namespace, encodedTopic);
         validateTopicPolicyOperationAsync(topicName, PolicyName.REPLICATION_RATE, PolicyOperation.READ)
             .thenCompose(__ -> preValidation(authoritative))
-            .thenCompose(__ -> internalGetReplicatorDispatchRate(applied, isGlobal))
+            .thenCompose(__ -> internalGetReplicatorDispatchRate(cluster, applied, isGlobal))
             .thenApply(asyncResponse::resume)
             .exceptionally(ex -> {
                 handleTopicPolicyException("getReplicatorDispatchRate", ex, asyncResponse);
@@ -2559,11 +2560,12 @@ public class PersistentTopics extends PersistentTopicsBase {
             @QueryParam("isGlobal") @DefaultValue("false") boolean isGlobal,
             @ApiParam(value = "Whether leader broker redirected this call to this broker. For internal use.")
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
+            @QueryParam("cluster") String cluster,
             @ApiParam(value = "Replicator dispatch rate of the topic") DispatchRateImpl dispatchRate) {
         validateTopicName(tenant, namespace, encodedTopic);
         validateTopicPolicyOperationAsync(topicName, PolicyName.REPLICATION_RATE, PolicyOperation.WRITE)
             .thenCompose(__ -> preValidation(authoritative))
-            .thenCompose(__ -> internalSetReplicatorDispatchRate(dispatchRate, isGlobal))
+            .thenCompose(__ -> internalSetReplicatorDispatchRate(cluster, dispatchRate, isGlobal))
             .thenRun(() -> {
                 log.info("[{}] Successfully updated replicatorDispatchRate: namespace={}, topic={}"
                                 + ", replicatorDispatchRate={}, isGlobal={}",
@@ -2590,11 +2592,12 @@ public class PersistentTopics extends PersistentTopicsBase {
             @PathParam("topic") @Encoded String encodedTopic,
             @QueryParam("isGlobal") @DefaultValue("false") boolean isGlobal,
             @ApiParam(value = "Whether leader broker redirected this call to this broker. For internal use.")
-            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
+            @QueryParam("cluster") String cluster) {
         validateTopicName(tenant, namespace, encodedTopic);
         validateTopicPolicyOperationAsync(topicName, PolicyName.REPLICATION_RATE, PolicyOperation.WRITE)
             .thenCompose(__ -> preValidation(authoritative))
-            .thenCompose(__ -> internalSetReplicatorDispatchRate(null, isGlobal))
+            .thenCompose(__ -> internalSetReplicatorDispatchRate(cluster, null, isGlobal))
             .thenRun(() -> {
                 log.info("[{}] Successfully remove replicatorDispatchRate limit: namespace={}, topic={}",
                         clientAppId(), namespaceName, topicName.getLocalName());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/AbstractTopic.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Lists;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -183,8 +184,14 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
         return this.topicPolicies.getSchemaCompatibilityStrategy().get();
     }
 
-    public DispatchRateImpl getReplicatorDispatchRate() {
-        return this.topicPolicies.getReplicatorDispatchRate().get();
+    public DispatchRateImpl getReplicatorDispatchRate(String remoteCluster) {
+        Map<String, DispatchRateImpl> dispatchRateMap = topicPolicies.getReplicatorDispatchRate().get();
+        DispatchRateImpl dispatchRate = dispatchRateMap.get(remoteCluster);
+        if (dispatchRate == null) {
+            // Use the default dispatch rate.
+            dispatchRate = dispatchRateMap.get(brokerService.pulsar().getConfiguration().getClusterName());
+        }
+        return normalize(dispatchRate);
     }
 
     public DispatchRateImpl getDispatchRate() {
@@ -225,7 +232,13 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
         topicPolicies.getMessageTTLInSeconds().updateTopicValue(data.getMessageTTLInSeconds());
         topicPolicies.getPublishRate().updateTopicValue(PublishRate.normalize(data.getPublishRate()));
         topicPolicies.getDelayedDeliveryEnabled().updateTopicValue(data.getDelayedDeliveryEnabled());
-        topicPolicies.getReplicatorDispatchRate().updateTopicValue(normalize(data.getReplicatorDispatchRate()));
+        // Backward compatibility.
+        // Default use the current cluster name as key, {@link TopicPolicies#getReplicatorDispatchRate()} is value.
+        HashMap<String, DispatchRateImpl> replicatorDispatchRateMap =
+                new HashMap<>(data.getReplicatorDispatchRateMap());
+        replicatorDispatchRateMap.putIfAbsent(brokerService.pulsar().getConfiguration().getClusterName(),
+                data.getReplicatorDispatchRate());
+        topicPolicies.getReplicatorDispatchRate().updateTopicValue(replicatorDispatchRateMap);
         topicPolicies.getDelayedDeliveryTickTimeMillis().updateTopicValue(data.getDelayedDeliveryTickTimeMillis());
         topicPolicies.getSubscribeRate().updateTopicValue(SubscribeRate.normalize(data.getSubscribeRate()));
         topicPolicies.getSubscriptionDispatchRate().updateTopicValue(normalize(data.getSubscriptionDispatchRate()));
@@ -272,8 +285,7 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
                         .map(DelayedDeliveryPolicies::getTickTime).orElse(null));
         topicPolicies.getSubscriptionTypesEnabled().updateNamespaceValue(
                 subTypeStringsToEnumSet(namespacePolicies.subscription_types_enabled));
-        updateNamespaceReplicatorDispatchRate(namespacePolicies,
-            brokerService.getPulsar().getConfig().getClusterName());
+        topicPolicies.getReplicatorDispatchRate().updateNamespaceValue(namespacePolicies.replicatorDispatchRate);
         Arrays.stream(BacklogQuota.BacklogQuotaType.values()).forEach(
                 type -> this.topicPolicies.getBackLogQuotaMap().get(type)
                         .updateNamespaceValue(MapUtils.getObject(namespacePolicies.backlog_quota_map, type)));
@@ -301,11 +313,6 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
     private void updateNamespaceSubscriptionDispatchRate(Policies namespacePolicies, String cluster) {
         topicPolicies.getSubscriptionDispatchRate()
             .updateNamespaceValue(normalize(namespacePolicies.subscriptionDispatchRate.get(cluster)));
-    }
-
-    private void updateNamespaceReplicatorDispatchRate(Policies namespacePolicies, String cluster) {
-        topicPolicies.getReplicatorDispatchRate()
-            .updateNamespaceValue(normalize(namespacePolicies.replicatorDispatchRate.get(cluster)));
     }
 
     private DispatchRateImpl normalize(DispatchRateImpl dispatchRate) {
@@ -411,12 +418,14 @@ public abstract class AbstractTopic implements Topic, TopicPolicyListener<TopicP
             .build();
     }
 
-    private DispatchRateImpl replicatorDispatchRateInBroker(ServiceConfiguration config) {
-        return DispatchRateImpl.builder()
-            .dispatchThrottlingRateInMsg(config.getDispatchThrottlingRatePerReplicatorInMsg())
-            .dispatchThrottlingRateInByte(config.getDispatchThrottlingRatePerReplicatorInByte())
-            .ratePeriodInSecond(1)
-            .build();
+    private Map<String, DispatchRateImpl> replicatorDispatchRateInBroker(ServiceConfiguration config) {
+        Map<String, DispatchRateImpl> dispatchRate = new HashMap<>();
+        dispatchRate.put(brokerService.pulsar().getConfiguration().getClusterName(), DispatchRateImpl.builder()
+                .dispatchThrottlingRateInMsg(config.getDispatchThrottlingRatePerReplicatorInMsg())
+                .dispatchThrottlingRateInByte(config.getDispatchThrottlingRatePerReplicatorInByte())
+                .ratePeriodInSecond(1)
+                .build());
+        return dispatchRate;
     }
 
     private EnumSet<SubType> subTypeStringsToEnumSet(Set<String> getSubscriptionTypesEnabled) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/DispatchRateLimiter.java
@@ -163,12 +163,16 @@ public class DispatchRateLimiter {
                 .build();
     }
 
+    public void updateDispatchRate(){
+        updateDispatchRate((String) null);
+    }
+
     /**
      * Update dispatch-throttling-rate.
      * Topic-level has the highest priority, then namespace-level, and finally use dispatch-throttling-rate in
      * broker-level
      */
-    public void updateDispatchRate() {
+    public void updateDispatchRate(String remoteCluster) {
         switch (type) {
             case TOPIC:
                 updateDispatchRate(topic.getDispatchRate());
@@ -177,7 +181,7 @@ public class DispatchRateLimiter {
                 updateDispatchRate(topic.getSubscriptionDispatchRate());
                 return;
             case REPLICATOR:
-                updateDispatchRate(topic.getReplicatorDispatchRate());
+                updateDispatchRate(topic.getReplicatorDispatchRate(remoteCluster));
                 return;
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -843,7 +843,7 @@ public class PersistentReplicator extends AbstractReplicator
     public void initializeDispatchRateLimiterIfNeeded() {
         synchronized (dispatchRateLimiterLock) {
             if (!dispatchRateLimiter.isPresent()
-                && DispatchRateLimiter.isDispatchRateEnabled(topic.getReplicatorDispatchRate())) {
+                && DispatchRateLimiter.isDispatchRateEnabled(topic.getReplicatorDispatchRate(remoteCluster))) {
                 this.dispatchRateLimiter = Optional.of(new DispatchRateLimiter(topic, Type.REPLICATOR));
             }
 
@@ -866,7 +866,7 @@ public class PersistentReplicator extends AbstractReplicator
     @Override
     public void updateRateLimiter() {
         initializeDispatchRateLimiterIfNeeded();
-        dispatchRateLimiter.ifPresent(DispatchRateLimiter::updateDispatchRate);
+        dispatchRateLimiter.ifPresent(n -> n.updateDispatchRate(remoteCluster));
     }
 
     private void checkReplicatedSubscriptionMarker(Position position, MessageImpl<?> msg, ByteBuf payload) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminReplicatorDispatchRateTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminReplicatorDispatchRateTest.java
@@ -1,0 +1,210 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.broker.admin;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.DispatchRate;
+import org.awaitility.Awaitility;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class AdminReplicatorDispatchRateTest extends MockedPulsarServiceBaseTest {
+    @BeforeClass
+    @Override
+    public void setup() throws Exception {
+        super.internalSetup();
+        setupDefaultTenantAndNamespace();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    public void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Override
+    protected void doInitConf() throws Exception {
+        super.doInitConf();
+        conf.setTopicLevelPoliciesEnabled(true);
+        conf.setSystemTopicEnabled(true);
+    }
+
+    @Test
+    public void testReplicatorDispatchRateOnTopicLevel() throws Exception {
+        TopicName topicName = TopicName.get("test-replicator-dispatch-rate");
+        String topic = topicName.toString();
+
+        admin.topics().createNonPartitionedTopic(topic);
+
+        Awaitility.await().untilAsserted(() -> {
+            assertNull(admin.topicPolicies().getReplicatorDispatchRate(topic, false));
+            // The broker config is used when the replicator dispatch rate is not set.
+            assertReplicatorDispatchRateByBrokerConfig(admin.topicPolicies().getReplicatorDispatchRate(topic, true));
+        });
+
+        // Set the default replicator dispatch rate on the topic level.
+        DispatchRate defaultDispatchRate = DispatchRate.builder()
+                .dispatchThrottlingRateInMsg(100)
+                .dispatchThrottlingRateInByte(200)
+                .ratePeriodInSecond(1)
+                .build();
+        admin.topicPolicies().setReplicatorDispatchRate(topic, defaultDispatchRate);
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic, false), defaultDispatchRate);
+            assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic, true), defaultDispatchRate);
+        });
+
+        // Set the replicator dispatch rate for the r1 cluster on the topic leve.
+        String r1Cluster = "r1";
+        DispatchRate r1DispatchRate = DispatchRate.builder()
+                .dispatchThrottlingRateInMsg(200)
+                .dispatchThrottlingRateInByte(400)
+                .ratePeriodInSecond(1)
+                .build();
+        admin.topicPolicies().setReplicatorDispatchRate(topic, r1Cluster, r1DispatchRate);
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic, true), defaultDispatchRate);
+            assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic, false), defaultDispatchRate);
+            assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic, r1Cluster, true), r1DispatchRate);
+            assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic, r1Cluster, false), r1DispatchRate);
+        });
+
+        // Remove the replicator dispatch rate for the r1 cluster on the topic level.
+        admin.topicPolicies().removeReplicatorDispatchRate(topic, r1Cluster);
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic, true), defaultDispatchRate);
+            assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic, false), defaultDispatchRate);
+            assertNull(admin.topicPolicies().getReplicatorDispatchRate(topic, r1Cluster, false));
+            assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic, r1Cluster, true), defaultDispatchRate);
+        });
+
+        // Remove the default replicator dispatch rate on the topic level.
+        admin.topicPolicies().removeReplicatorDispatchRate(topic);
+        Awaitility.await().untilAsserted(() -> {
+            assertNull(admin.topicPolicies().getReplicatorDispatchRate(topic, false));
+            assertNull(admin.topicPolicies().getReplicatorDispatchRate(topic, r1Cluster, false));
+            // The broker config is used when the replicator dispatch rate is not set on any level.
+            assertReplicatorDispatchRateByBrokerConfig(
+                    admin.topicPolicies().getReplicatorDispatchRate(topic, r1Cluster, true));
+            assertReplicatorDispatchRateByBrokerConfig(admin.topicPolicies().getReplicatorDispatchRate(topic, true));
+        });
+    }
+
+    @Test
+    public void testReplicatorDispatchRateOnNamespaceAndTopicLevels() throws Exception {
+        String namespace = "public/test-replicator-dispatch-rate-ns";
+        admin.namespaces().createNamespace(namespace);
+
+        // Set the default replicator dispatch rate.
+        DispatchRate defaultDispatchRateOnNamespace = DispatchRate.builder()
+                .dispatchThrottlingRateInMsg(100)
+                .dispatchThrottlingRateInByte(200)
+                .ratePeriodInSecond(1)
+                .build();
+        admin.namespaces().setReplicatorDispatchRate(namespace, defaultDispatchRateOnNamespace);
+        assertEquals(admin.namespaces().getReplicatorDispatchRate(namespace), defaultDispatchRateOnNamespace);
+
+        // Set the replicator dispatch rate for the r1 cluster.
+        String r1Cluster = "r1";
+        DispatchRate r1DispatchRateOnNamespace = DispatchRate.builder()
+                .dispatchThrottlingRateInMsg(200)
+                .dispatchThrottlingRateInByte(400)
+                .ratePeriodInSecond(1)
+                .build();
+        admin.namespaces().setReplicatorDispatchRate(namespace, r1Cluster, r1DispatchRateOnNamespace);
+        assertEquals(admin.namespaces().getReplicatorDispatchRate(namespace), defaultDispatchRateOnNamespace);
+        assertEquals(admin.namespaces().getReplicatorDispatchRate(namespace, r1Cluster), r1DispatchRateOnNamespace);
+
+        // Topic inherits the namespace level replicator dispatch rate.
+        String topic = TopicName.get(namespace + "/test-replicator-dispatch-rate").toString();
+        admin.topics().createNonPartitionedTopic(topic);
+        assertNull(admin.topicPolicies().getReplicatorDispatchRate(topic));
+        assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic, true), defaultDispatchRateOnNamespace);
+        assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic, r1Cluster, true),
+                r1DispatchRateOnNamespace);
+
+        // Topic overrides the namespace level replicator dispatch rate.
+        DispatchRate defaultDispatchRateOnTopic = DispatchRate.builder()
+                .dispatchThrottlingRateInMsg(300)
+                .dispatchThrottlingRateInByte(600)
+                .ratePeriodInSecond(1)
+                .build();
+        admin.topicPolicies().setReplicatorDispatchRate(topic, defaultDispatchRateOnTopic);
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic, false), defaultDispatchRateOnTopic);
+            assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic, true), defaultDispatchRateOnTopic);
+        });
+
+        DispatchRate topicDispatchRateForR1 = DispatchRate.builder()
+                .dispatchThrottlingRateInMsg(400)
+                .dispatchThrottlingRateInByte(800)
+                .ratePeriodInSecond(1)
+                .build();
+        admin.topicPolicies().setReplicatorDispatchRate(topic, r1Cluster, topicDispatchRateForR1);
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic, r1Cluster, false),
+                    topicDispatchRateForR1);
+            assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic, r1Cluster, true),
+                    topicDispatchRateForR1);
+        });
+
+        // r1 cluster's dispatch rate is removed.
+        // If applied is true, return default dispatch rate, otherwise, return null.
+        admin.topicPolicies().removeReplicatorDispatchRate(topic, r1Cluster);
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic, r1Cluster, true), defaultDispatchRateOnTopic);
+            assertNull(admin.topicPolicies().getReplicatorDispatchRate(topic, r1Cluster, false));
+        });
+
+        // The default dispatch rate is removed.
+        // If applied is true, return namespace level config, otherwise, return null.
+        admin.topicPolicies().removeReplicatorDispatchRate(topic);
+        Awaitility.await().untilAsserted(() -> {
+            assertNull(admin.topicPolicies().getReplicatorDispatchRate(topic, false));
+            assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic, true), defaultDispatchRateOnNamespace);
+        });
+
+        // Remove the replicator dispatch rate for the r1 cluster.
+        admin.namespaces().removeReplicatorDispatchRate(namespace, r1Cluster);
+        assertEquals(admin.namespaces().getReplicatorDispatchRate(namespace), defaultDispatchRateOnNamespace);
+        assertNull(admin.namespaces().getReplicatorDispatchRate(namespace, r1Cluster));
+
+        // Remove the default replicator dispatch rate.
+        admin.namespaces().removeReplicatorDispatchRate(namespace);
+        assertNull(admin.namespaces().getReplicatorDispatchRate(namespace));
+
+        // The broker config is used when the replicator dispatch rate is not set on any level.
+        Awaitility.await().untilAsserted(() -> assertReplicatorDispatchRateByBrokerConfig(
+                admin.topicPolicies().getReplicatorDispatchRate(topic, r1Cluster, true)));
+    }
+
+    private void assertReplicatorDispatchRateByBrokerConfig(DispatchRate replicatorDispatchRate) {
+        assertNotNull(replicatorDispatchRate);
+        assertEquals(replicatorDispatchRate.getDispatchThrottlingRateInByte(),
+                conf.getDispatchThrottlingRatePerReplicatorInByte());
+        assertEquals(replicatorDispatchRate.getDispatchThrottlingRateInByte(),
+                conf.getDispatchThrottlingRatePerReplicatorInMsg());
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
@@ -26,11 +26,13 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertFalse;
 import com.google.common.collect.Sets;
 import java.lang.reflect.Method;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Cleanup;
 import org.apache.pulsar.broker.resourcegroup.ResourceGroupDispatchLimiter;
+import org.apache.pulsar.broker.service.persistent.DispatchRateLimiter;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.MessageRoutingMode;
@@ -698,6 +700,94 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
                     assertThat(totalReceived.get()).isLessThan((byteRate / payloadSize) + 2);
                 });
     }
+
+    @Test
+    public void testLoadReplicatorDispatchRateLimiterByTopicPolicies() throws Exception {
+        final String namespace = "pulsar/replicator-dispatch-rate-" + System.currentTimeMillis();
+        final String topicName = "persistent://" + namespace + "/" + System.currentTimeMillis();
+
+        admin1.namespaces().createNamespace(namespace);
+        admin1.namespaces().setNamespaceReplicationClusters(namespace, Sets.newHashSet("r1", "r2"));
+
+        final int byteRate = 400;
+        DispatchRate dispatchRate = DispatchRate.builder()
+                .dispatchThrottlingRateInMsg(-1)
+                .dispatchThrottlingRateInByte(byteRate)
+                .ratePeriodInSecond(1)
+                .build();
+        admin1.namespaces().setReplicatorDispatchRate(namespace, dispatchRate);
+
+        admin1.topics().createNonPartitionedTopic(topicName);
+
+        Optional<Topic> topicOptional = pulsar1.getBrokerService().getTopicIfExists(topicName).get();
+        assertTrue(topicOptional.isPresent());
+
+        PersistentTopic topic = (PersistentTopic) topicOptional.get();
+        Awaitility.await()
+                .untilAsserted(() -> {
+                    Optional<DispatchRateLimiter> rateLimiter = topic.getReplicators().values().get(0).getRateLimiter();
+                    assertTrue(rateLimiter.isPresent());
+                    assertEquals(rateLimiter.get().getDispatchRateOnByte(), byteRate);
+                });
+
+        // r1 -> r2: limits this replication channel by the namespace policy
+        long dispatchThrottlingRateInMsgWhenR1ToR2OnNs = 3000;
+        long dispatchThrottlingRateInByteWhenR1ToR2OnNs = 2000;
+        DispatchRate dispatchRateOnNamespace = DispatchRate.builder()
+                .dispatchThrottlingRateInMsg((int) dispatchThrottlingRateInMsgWhenR1ToR2OnNs)
+                .dispatchThrottlingRateInByte(dispatchThrottlingRateInByteWhenR1ToR2OnNs)
+                .ratePeriodInSecond(1)
+                .build();
+        admin1.namespaces().setReplicatorDispatchRate(namespace, "r2", dispatchRateOnNamespace);
+        Awaitility.await()
+                .untilAsserted(() -> {
+                    Optional<DispatchRateLimiter> rateLimiter = topic.getReplicators().values().get(0).getRateLimiter();
+                    assertTrue(rateLimiter.isPresent());
+                    assertEquals(rateLimiter.get().getDispatchRateOnByte(), dispatchThrottlingRateInByteWhenR1ToR2OnNs);
+                    assertEquals(rateLimiter.get().getDispatchRateOnMsg(), dispatchThrottlingRateInMsgWhenR1ToR2OnNs);
+                });
+
+        // r1 -> r2: limits this replication channel by default dispatch rate on the topic level.
+        long defaultDispatchThrottlingRateInMsgOnTopic = 30000;
+        long defaultDispatchThrottlingRateInByteOnTopic = 20000;
+        DispatchRate dispatchRateOnTopic = DispatchRate.builder()
+                .dispatchThrottlingRateInMsg((int) defaultDispatchThrottlingRateInMsgOnTopic)
+                .dispatchThrottlingRateInByte(defaultDispatchThrottlingRateInByteOnTopic)
+                .ratePeriodInSecond(1)
+                .build();
+
+        admin1.topicPolicies().setReplicatorDispatchRate(topicName, dispatchRateOnTopic);
+        Awaitility.await()
+                .untilAsserted(() -> {
+                    Optional<DispatchRateLimiter> rateLimiter = topic.getReplicators().values().get(0).getRateLimiter();
+                    assertTrue(rateLimiter.isPresent());
+                    assertEquals(rateLimiter.get().getDispatchRateOnByte(),
+                            defaultDispatchThrottlingRateInByteOnTopic);
+                    assertEquals(rateLimiter.get().getDispatchRateOnMsg(),
+                            defaultDispatchThrottlingRateInMsgOnTopic);
+                });
+
+        // r1 -> r2: limits this replication channel by the specific cluster on the topic level.
+        long dispatchThrottlingRateInMsgBetweenR1AndR2OnTopic = 50000;
+        long dispatchThrottlingRateInByteBetweenR1AndR2OnTopic = 40000;
+        DispatchRate dispatchRateBetweenR1AndR2OnTopic = DispatchRate.builder()
+                .dispatchThrottlingRateInMsg((int) dispatchThrottlingRateInMsgBetweenR1AndR2OnTopic)
+                .dispatchThrottlingRateInByte(dispatchThrottlingRateInByteBetweenR1AndR2OnTopic)
+                .ratePeriodInSecond(1)
+                .build();
+
+        admin1.topicPolicies().setReplicatorDispatchRate(topicName, "r2", dispatchRateBetweenR1AndR2OnTopic);
+        Awaitility.await()
+                .untilAsserted(() -> {
+                    Optional<DispatchRateLimiter> rateLimiter = topic.getReplicators().values().get(0).getRateLimiter();
+                    assertTrue(rateLimiter.isPresent());
+                    assertEquals(rateLimiter.get().getDispatchRateOnByte(),
+                            dispatchThrottlingRateInByteBetweenR1AndR2OnTopic);
+                    assertEquals(rateLimiter.get().getDispatchRateOnMsg(),
+                            dispatchThrottlingRateInMsgBetweenR1AndR2OnTopic);
+                });
+    }
+
 
     private static final Logger log = LoggerFactory.getLogger(ReplicatorRateLimiterTest.class);
 }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -2319,6 +2319,21 @@ public interface Namespaces {
     void setReplicatorDispatchRate(String namespace, DispatchRate dispatchRate) throws PulsarAdminException;
 
     /**
+     * Set replicator-message-dispatch-rate.
+     * <p/>
+     * Replicators under this namespace can dispatch this many messages per second.
+     *
+     * @param namespace
+     * @param cluster The cluster for which to set the replicator dispatch rate.
+     * @param dispatchRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setReplicatorDispatchRate(String namespace, String cluster, DispatchRate dispatchRate)
+            throws PulsarAdminException;
+
+    /**
      * Set replicator-message-dispatch-rate asynchronously.
      * <p/>
      * Replicators under this namespace can dispatch this many messages per second.
@@ -2330,6 +2345,18 @@ public interface Namespaces {
     CompletableFuture<Void> setReplicatorDispatchRateAsync(String namespace, DispatchRate dispatchRate);
 
     /**
+     * Set replicator-message-dispatch-rate asynchronously.
+     * <p/>
+     * Replicators under this namespace can dispatch this many messages per second.
+     *
+     * @param namespace
+     * @param cluster The cluster for which to set the replicator dispatch rate.
+     * @param dispatchRate
+     *            number of messages per second
+     */
+    CompletableFuture<Void> setReplicatorDispatchRateAsync(String namespace, String cluster, DispatchRate dispatchRate);
+
+    /**
      * Remove replicator-message-dispatch-rate.
      *
      * @param namespace
@@ -2339,11 +2366,29 @@ public interface Namespaces {
     void removeReplicatorDispatchRate(String namespace) throws PulsarAdminException;
 
     /**
+     * Remove replicator-message-dispatch-rate.
+     *
+     * @param namespace
+     * @param cluster The cluster for which to remove the replicator dispatch rate.
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void removeReplicatorDispatchRate(String namespace, String cluster) throws PulsarAdminException;
+
+    /**
      * Set replicator-message-dispatch-rate asynchronously.
      *
      * @param namespace
      */
     CompletableFuture<Void> removeReplicatorDispatchRateAsync(String namespace);
+
+    /**
+     * Set replicator-message-dispatch-rate asynchronously.
+     *
+     * @param namespace
+     * @param cluster The cluster for which to remove the replicator dispatch rate.
+     */
+    CompletableFuture<Void> removeReplicatorDispatchRateAsync(String namespace, String cluster);
 
     /**
      * Get replicator-message-dispatch-rate.
@@ -2359,6 +2404,20 @@ public interface Namespaces {
     DispatchRate getReplicatorDispatchRate(String namespace) throws PulsarAdminException;
 
     /**
+     * Get replicator-message-dispatch-rate.
+     * <p/>
+     * Replicators under this namespace can dispatch this many messages per second.
+     *
+     * @param namespace
+     * @param cluster The cluster for which to get the replicator dispatch rate.
+     * @returns DispatchRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    DispatchRate getReplicatorDispatchRate(String namespace, String cluster) throws PulsarAdminException;
+
+    /**
      * Get replicator-message-dispatch-rate asynchronously.
      * <p/>
      * Replicators under this namespace can dispatch this many messages per second.
@@ -2368,6 +2427,18 @@ public interface Namespaces {
      *            number of messages per second
      */
     CompletableFuture<DispatchRate> getReplicatorDispatchRateAsync(String namespace);
+
+    /**
+     * Get replicator-message-dispatch-rate asynchronously.
+     * <p/>
+     * Replicators under this namespace can dispatch this many messages per second.
+     *
+     * @param namespace
+     * @param cluster The cluster for which to get the dispatch rate.
+     * @returns DispatchRate
+     *            number of messages per second
+     */
+    CompletableFuture<DispatchRate> getReplicatorDispatchRateAsync(String namespace, String cluster);
 
     /**
      * Clear backlog for all topics on a namespace.

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/TopicPolicies.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/TopicPolicies.java
@@ -926,6 +926,20 @@ public interface TopicPolicies {
     void setReplicatorDispatchRate(String topic, DispatchRate dispatchRate) throws PulsarAdminException;
 
     /**
+     * Set replicatorDispatchRate for the topic.
+     * <p/>
+     * Replicator dispatch rate under this topic can dispatch this many messages per second
+     *
+     * @param topic
+     * @param cluster The cluster for which set the replicator dispatch rate.
+     * @param dispatchRate
+     *            number of messages per second
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void setReplicatorDispatchRate(String topic, String cluster, DispatchRate dispatchRate) throws PulsarAdminException;
+
+    /**
      * Set replicatorDispatchRate for the topic asynchronously.
      * <p/>
      * Replicator dispatch rate under this topic can dispatch this many messages per second.
@@ -935,6 +949,17 @@ public interface TopicPolicies {
      *            number of messages per second
      */
     CompletableFuture<Void> setReplicatorDispatchRateAsync(String topic, DispatchRate dispatchRate);
+
+    /**
+     * Set replicatorDispatchRate for the topic asynchronously.
+     * <p/>
+     * Replicator dispatch rate under this topic can dispatch this many messages per second.
+     *
+     * @param topic
+     * @param cluster      The cluster for which set the replicator dispatch rate.
+     * @param dispatchRate number of messages per second
+     */
+    CompletableFuture<Void> setReplicatorDispatchRateAsync(String topic, String cluster, DispatchRate dispatchRate);
 
     /**
      * Get replicatorDispatchRate for the topic.
@@ -970,12 +995,31 @@ public interface TopicPolicies {
     DispatchRate getReplicatorDispatchRate(String topic, boolean applied) throws PulsarAdminException;
 
     /**
+     * Get applied replicatorDispatchRate for the topic.
+     * @param topic
+     * @param cluster The cluster for which get the replicator dispatch rate.
+     * @param applied
+     * @return
+     * @throws PulsarAdminException
+     */
+    DispatchRate getReplicatorDispatchRate(String topic, String cluster, boolean applied) throws PulsarAdminException;
+
+    /**
      * Get applied replicatorDispatchRate asynchronously.
      * @param topic
      * @param applied
      * @return
      */
     CompletableFuture<DispatchRate> getReplicatorDispatchRateAsync(String topic, boolean applied);
+
+    /**
+     * Get applied replicatorDispatchRate asynchronously.
+     * @param topic
+     * @param cluster The cluster for which get the replicator dispatch rate.
+     * @param applied
+     * @return
+     */
+    CompletableFuture<DispatchRate> getReplicatorDispatchRateAsync(String topic, String cluster, boolean applied);
 
     /**
      * Remove replicatorDispatchRate for a topic.
@@ -987,11 +1031,29 @@ public interface TopicPolicies {
     void removeReplicatorDispatchRate(String topic) throws PulsarAdminException;
 
     /**
+     * Remove replicatorDispatchRate for a topic.
+     * @param topic
+     *            Topic name
+     * @param cluster The cluster for which remove the replicator dispatch rate.
+     * @throws PulsarAdminException
+     *            Unexpected error
+     */
+    void removeReplicatorDispatchRate(String topic, String cluster) throws PulsarAdminException;
+
+    /**
      * Remove replicatorDispatchRate for a topic asynchronously.
      * @param topic
      *            Topic name
      */
     CompletableFuture<Void> removeReplicatorDispatchRateAsync(String topic);
+
+    /**
+     * Remove replicatorDispatchRate for a topic asynchronously.
+     * @param topic
+     *            Topic name
+     * @param cluster The cluster for which remove the replicator dispatch rate.
+     */
+    CompletableFuture<Void> removeReplicatorDispatchRateAsync(String topic, String cluster);
 
     /**
      * Get the compactionThreshold for a topic. The maximum number of bytes

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -1325,8 +1325,20 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
 
     @Override
     public CompletableFuture<Void> setReplicatorDispatchRateAsync(String namespace, DispatchRate dispatchRate) {
+        return setReplicatorDispatchRateAsync(namespace, null, dispatchRate);
+    }
+
+    @Override
+    public void setReplicatorDispatchRate(String namespace, String cluster, DispatchRate dispatchRate)
+            throws PulsarAdminException {
+        sync(() -> setReplicatorDispatchRateAsync(namespace, cluster, dispatchRate));
+    }
+
+    @Override
+    public CompletableFuture<Void> setReplicatorDispatchRateAsync(String namespace, String cluster,
+                                                                  DispatchRate dispatchRate) {
         NamespaceName ns = NamespaceName.get(namespace);
-        WebTarget path = namespacePath(ns, "replicatorDispatchRate");
+        WebTarget path = namespacePath(ns, "replicatorDispatchRate").queryParam("cluster", cluster);
         return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
     }
 
@@ -1337,8 +1349,18 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
 
     @Override
     public CompletableFuture<Void> removeReplicatorDispatchRateAsync(String namespace) {
+        return removeReplicatorDispatchRateAsync(namespace, null);
+    }
+
+    @Override
+    public void removeReplicatorDispatchRate(String namespace, String cluster) throws PulsarAdminException {
+        sync(() -> removeReplicatorDispatchRateAsync(namespace, cluster));
+    }
+
+    @Override
+    public CompletableFuture<Void> removeReplicatorDispatchRateAsync(String namespace, String cluster) {
         NamespaceName ns = NamespaceName.get(namespace);
-        WebTarget path = namespacePath(ns, "replicatorDispatchRate");
+        WebTarget path = namespacePath(ns, "replicatorDispatchRate").queryParam("cluster", cluster);
         return asyncDeleteRequest(path);
     }
 
@@ -1348,9 +1370,19 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     }
 
     @Override
+    public DispatchRate getReplicatorDispatchRate(String namespace, String cluster) throws PulsarAdminException {
+        return sync(()-> getReplicatorDispatchRateAsync(namespace, cluster));
+    }
+
+    @Override
     public CompletableFuture<DispatchRate> getReplicatorDispatchRateAsync(String namespace) {
+        return getReplicatorDispatchRateAsync(namespace, null);
+    }
+
+    @Override
+    public CompletableFuture<DispatchRate> getReplicatorDispatchRateAsync(String namespace, String cluster) {
         NamespaceName ns = NamespaceName.get(namespace);
-        WebTarget path = namespacePath(ns, "replicatorDispatchRate");
+        WebTarget path = namespacePath(ns, "replicatorDispatchRate").queryParam("cluster", cluster);
         final CompletableFuture<DispatchRate> future = new CompletableFuture<>();
         asyncGetRequest(path,
                 new InvocationCallback<DispatchRate>() {

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicPoliciesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicPoliciesImpl.java
@@ -1321,9 +1321,21 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
 
     @Override
     public CompletableFuture<DispatchRate> getReplicatorDispatchRateAsync(String topic, boolean applied) {
+        return getReplicatorDispatchRateAsync(topic, null, applied);
+    }
+
+    @Override
+    public DispatchRate getReplicatorDispatchRate(String topic, String cluster, boolean applied)
+            throws PulsarAdminException {
+        return sync(() -> getReplicatorDispatchRateAsync(topic, cluster, applied));
+    }
+
+    @Override
+    public CompletableFuture<DispatchRate> getReplicatorDispatchRateAsync(String topic, String cluster,
+                                                                          boolean applied) {
         TopicName topicName = validateTopic(topic);
-        WebTarget path = topicPath(topicName, "replicatorDispatchRate");
-        path = path.queryParam("applied", applied);
+        WebTarget path = topicPath(topicName, "replicatorDispatchRate").queryParam("applied", applied)
+                .queryParam("cluster", cluster);
         final CompletableFuture<DispatchRate> future = new CompletableFuture<>();
         asyncGetRequest(path,
                 new InvocationCallback<DispatchRate>() {
@@ -1347,8 +1359,20 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
 
     @Override
     public CompletableFuture<Void> setReplicatorDispatchRateAsync(String topic, DispatchRate dispatchRate) {
+        return setReplicatorDispatchRateAsync(topic, null, dispatchRate);
+    }
+
+    @Override
+    public void setReplicatorDispatchRate(String topic, String cluster, DispatchRate dispatchRate)
+            throws PulsarAdminException {
+        sync(() -> setReplicatorDispatchRateAsync(topic, cluster, dispatchRate));
+    }
+
+    @Override
+    public CompletableFuture<Void> setReplicatorDispatchRateAsync(String topic, String cluster,
+                                                                  DispatchRate dispatchRate) {
         TopicName tn = validateTopic(topic);
-        WebTarget path = topicPath(tn, "replicatorDispatchRate");
+        WebTarget path = topicPath(tn, "replicatorDispatchRate").queryParam("cluster", cluster);
         return asyncPostRequest(path, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
     }
 
@@ -1359,8 +1383,18 @@ public class TopicPoliciesImpl extends BaseResource implements TopicPolicies {
 
     @Override
     public CompletableFuture<Void> removeReplicatorDispatchRateAsync(String topic) {
+        return removeReplicatorDispatchRateAsync(topic, null);
+    }
+
+    @Override
+    public void removeReplicatorDispatchRate(String topic, String cluster) throws PulsarAdminException {
+        sync(() -> removeReplicatorDispatchRateAsync(topic, cluster));
+    }
+
+    @Override
+    public CompletableFuture<Void> removeReplicatorDispatchRateAsync(String topic, String cluster) {
         TopicName tn = validateTopic(topic);
-        WebTarget path = topicPath(tn, "replicatorDispatchRate");
+        WebTarget path = topicPath(tn, "replicatorDispatchRate").queryParam("cluster", cluster);
         return asyncDeleteRequest(path);
     }
 

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -962,15 +962,16 @@ public class PulsarAdminToolTest {
 
         cmdTopics.run(split("set-replicator-dispatch-rate persistent://myprop/clust/ns1/ds1 -md -1 -bd -1 -dt 2"));
         verify(mockTopicsPolicies).setReplicatorDispatchRate("persistent://myprop/clust/ns1/ds1",
+                null,
                 DispatchRate.builder()
                         .dispatchThrottlingRateInMsg(-1)
                         .dispatchThrottlingRateInByte(-1)
                         .ratePeriodInSecond(2)
                         .build());
         cmdTopics.run(split("get-replicator-dispatch-rate persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).getReplicatorDispatchRate("persistent://myprop/clust/ns1/ds1", false);
+        verify(mockTopicsPolicies).getReplicatorDispatchRate("persistent://myprop/clust/ns1/ds1", null, false);
         cmdTopics.run(split("remove-replicator-dispatch-rate persistent://myprop/clust/ns1/ds1"));
-        verify(mockTopicsPolicies).removeReplicatorDispatchRate("persistent://myprop/clust/ns1/ds1");
+        verify(mockTopicsPolicies).removeReplicatorDispatchRate("persistent://myprop/clust/ns1/ds1", null);
 
         cmdTopics.run(split("set-subscription-dispatch-rate persistent://myprop/clust/ns1/ds1 -md -1 -bd -1 -dt 2"));
         verify(mockTopicsPolicies).setSubscriptionDispatchRate("persistent://myprop/clust/ns1/ds1",
@@ -1248,15 +1249,16 @@ public class PulsarAdminToolTest {
 
         cmdTopics.run(split("set-replicator-dispatch-rate persistent://myprop/clust/ns1/ds1 -md -1 -bd -1 -dt 2 -g"));
         verify(mockGlobalTopicsPolicies).setReplicatorDispatchRate("persistent://myprop/clust/ns1/ds1",
+                null,
                 DispatchRate.builder()
                         .dispatchThrottlingRateInMsg(-1)
                         .dispatchThrottlingRateInByte(-1)
                         .ratePeriodInSecond(2)
                         .build());
         cmdTopics.run(split("get-replicator-dispatch-rate persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).getReplicatorDispatchRate("persistent://myprop/clust/ns1/ds1", false);
+        verify(mockGlobalTopicsPolicies).getReplicatorDispatchRate("persistent://myprop/clust/ns1/ds1", null, false);
         cmdTopics.run(split("remove-replicator-dispatch-rate persistent://myprop/clust/ns1/ds1 -g"));
-        verify(mockGlobalTopicsPolicies).removeReplicatorDispatchRate("persistent://myprop/clust/ns1/ds1");
+        verify(mockGlobalTopicsPolicies).removeReplicatorDispatchRate("persistent://myprop/clust/ns1/ds1", null);
 
         cmdTopics.run(split("set-subscription-dispatch-rate persistent://myprop/clust/ns1/ds1 -md -1 -bd -1 -dt 2 -g"));
         verify(mockGlobalTopicsPolicies).setSubscriptionDispatchRate("persistent://myprop/clust/ns1/ds1",

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -1134,10 +1134,14 @@ public class CmdNamespaces extends CmdBase {
                 + "(default 1 second will be overwrite if not passed)", required = false)
         private int dispatchRatePeriodSec = 1;
 
+        @Parameter(names = "--cluster", description = "The remote cluster for which set the dispatch rate, default to"
+                + " null", required = false)
+        private String cluster = null;
+
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            getAdmin().namespaces().setReplicatorDispatchRate(namespace,
+            getAdmin().namespaces().setReplicatorDispatchRate(namespace, cluster,
                     DispatchRate.builder()
                             .dispatchThrottlingRateInMsg(msgDispatchRate)
                             .dispatchThrottlingRateInByte(byteDispatchRate)
@@ -1152,10 +1156,14 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
+        @Parameter(names = "--cluster", description = "The remote cluster for which set the dispatch rate, default to"
+                + " null", required = false)
+        private String cluster = null;
+
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            print(getAdmin().namespaces().getReplicatorDispatchRate(namespace));
+            print(getAdmin().namespaces().getReplicatorDispatchRate(namespace, cluster));
         }
     }
 
@@ -1165,10 +1173,14 @@ public class CmdNamespaces extends CmdBase {
         @Parameter(description = "tenant/namespace", required = true)
         private java.util.List<String> params;
 
+        @Parameter(names = "--cluster", description = "The remote cluster for which set the dispatch rate, default to"
+                + " null", required = false)
+        private String cluster = null;
+
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            getAdmin().namespaces().removeReplicatorDispatchRate(namespace);
+            getAdmin().namespaces().removeReplicatorDispatchRate(namespace, cluster);
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopicPolicies.java
@@ -1377,10 +1377,14 @@ public class CmdTopicPolicies extends CmdBase {
                 + "If set to true, broker returned global topic policies")
         private boolean isGlobal = false;
 
+        @Parameter(names = "--cluster", description = "The remote cluster for which set the dispatch rate, default to"
+                + " null", required = false)
+        private String cluster = null;
+
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            print(getTopicPolicies(isGlobal).getReplicatorDispatchRate(persistentTopic, applied));
+            print(getTopicPolicies(isGlobal).getReplicatorDispatchRate(persistentTopic, cluster, applied));
         }
     }
 
@@ -1411,10 +1415,14 @@ public class CmdTopicPolicies extends CmdBase {
                 + "If set to true, the policy will be replicate to other clusters asynchronously")
         private boolean isGlobal = false;
 
+        @Parameter(names = "--cluster", description = "The remote cluster for which set the dispatch rate, default to"
+                + " null", required = false)
+        private String cluster = null;
+
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            getTopicPolicies(isGlobal).setReplicatorDispatchRate(persistentTopic,
+            getTopicPolicies(isGlobal).setReplicatorDispatchRate(persistentTopic, cluster,
                     DispatchRate.builder()
                             .dispatchThrottlingRateInMsg(msgDispatchRate)
                             .dispatchThrottlingRateInByte(byteDispatchRate)
@@ -1433,10 +1441,14 @@ public class CmdTopicPolicies extends CmdBase {
                 + "If set to true, the policy will be replicate to other clusters asynchronously")
         private boolean isGlobal = false;
 
+        @Parameter(names = "--cluster", description = "The remote cluster for which set the dispatch rate, default to"
+                + " null", required = false)
+        private String cluster = null;
+
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            getTopicPolicies(isGlobal).removeReplicatorDispatchRate(persistentTopic);
+            getTopicPolicies(isGlobal).removeReplicatorDispatchRate(persistentTopic, cluster);
         }
 
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/HierarchyTopicPolicies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/HierarchyTopicPolicies.java
@@ -51,7 +51,7 @@ public class HierarchyTopicPolicies {
     final PolicyHierarchyValue<PublishRate> publishRate;
     final PolicyHierarchyValue<Boolean> delayedDeliveryEnabled;
     final PolicyHierarchyValue<Long> delayedDeliveryTickTimeMillis;
-    final PolicyHierarchyValue<DispatchRateImpl> replicatorDispatchRate;
+    final PolicyHierarchyValue<Map<String, DispatchRateImpl>> replicatorDispatchRate;
     final PolicyHierarchyValue<Integer> maxConsumersPerSubscription;
     final PolicyHierarchyValue<SubscribeRate> subscribeRate;
     final PolicyHierarchyValue<DispatchRateImpl> subscriptionDispatchRate;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TopicPolicies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TopicPolicies.java
@@ -69,7 +69,13 @@ public class TopicPolicies {
     private Integer deduplicationSnapshotIntervalSeconds;
     private Integer maxMessageSize;
     private Integer maxSubscriptionsPerTopic;
+    /**
+     * @deprecated Use {@link #replicatorDispatchRateMap} instead.
+     */
+    @Deprecated
     private DispatchRateImpl replicatorDispatchRate;
+    @Builder.Default
+    private Map<String, DispatchRateImpl> replicatorDispatchRateMap = new HashMap<>();
     private SchemaCompatibilityStrategy schemaCompatibilityStrategy;
     private String resourceGroupName;
     private Boolean replicateSubscriptionState;


### PR DESCRIPTION
### Motivation

This PR enhances Pulsar's replication capabilities by adding support for configuring replicator rate limiters on a per-cluster basis. Currently, Pulsar only supports a single global replicator dispatch rate that applies to all remote clusters. This limitation makes it difficult to optimize replication performance when different destination clusters have varying network conditions or resource constraints.

By allowing administrators to configure different dispatch rates for different destination clusters, this PR enables more granular control over replication traffic, which can help prevent network congestion and improve overall system stability.

### Modifications

- Added support for configuring replicator dispatch rates on a per-cluster basis at both namespace and topic levels.
- Extended the Admin API to support cluster-specific replicator dispatch rate operations.
- Modified the internal replicator implementation to use cluster-specific rate limiters when available.
- Updated the CLI commands to support the new cluster parameter.
- Maintained backward compatibility with existing configurations.
- Added comprehensive test coverage for the new functionality.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->