### PR TITLE
[feat][broker] Add metrics for marker and snapshot

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -890,7 +890,7 @@ public class PersistentReplicator extends AbstractReplicator
         case MarkerType.REPLICATED_SUBSCRIPTION_SNAPSHOT_REQUEST_VALUE:
         case MarkerType.REPLICATED_SUBSCRIPTION_SNAPSHOT_RESPONSE_VALUE:
         case MarkerType.REPLICATED_SUBSCRIPTION_UPDATE_VALUE:
-            topic.receivedReplicatedSubscriptionMarker(position, markerType, payload);
+            topic.receivedReplicatedSubscriptionMarker(msg.getReplicatedFrom(), position, markerType, payload);
             break;
 
         default:

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -2990,7 +2990,8 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
         }
     }
 
-    void receivedReplicatedSubscriptionMarker(Position position, int markerType, ByteBuf payload) {
+    void receivedReplicatedSubscriptionMarker(String remoteCluster, Position position, int markerType,
+                                              ByteBuf payload) {
         ReplicatedSubscriptionsController ctrl = replicatedSubscriptionsController.orElse(null);
         if (ctrl == null) {
             // Force to start the replication controller
@@ -2998,7 +2999,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
             ctrl = replicatedSubscriptionsController.get();
         }
 
-        ctrl.receivedReplicatedSubscriptionMarker(position, markerType, payload);
+        ctrl.receivedReplicatedSubscriptionMarker(remoteCluster, position, markerType, payload);
      }
 
     public Optional<ReplicatedSubscriptionsController> getReplicatedSubscriptionController() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/ReplicatedSubscriptionsController.java
@@ -18,8 +18,12 @@
  */
 package org.apache.pulsar.broker.service.persistent;
 
+import static org.apache.pulsar.common.api.proto.MarkerType.REPLICATED_SUBSCRIPTION_SNAPSHOT_REQUEST;
+import static org.apache.pulsar.common.api.proto.MarkerType.REPLICATED_SUBSCRIPTION_SNAPSHOT_RESPONSE;
+import static org.apache.pulsar.common.api.proto.MarkerType.REPLICATED_SUBSCRIPTION_UPDATE;
 import static org.apache.pulsar.common.util.Runnables.catchingAndLoggingThrowables;
 import io.netty.buffer.ByteBuf;
+import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import java.io.IOException;
 import java.time.Clock;
@@ -75,6 +79,22 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
                     "Counter of currently pending snapshots")
             .register();
 
+    private static final Counter snapshotOperationCounter = Counter
+            .build("pulsar_broker_replication_subscription_snapshot_operation_count",
+                    "The number of snapshot operations attempted")
+            .register();
+
+    private static final Counter writtenMarkerMessageCounter = Counter
+            .build("pulsar_broker_replication_marker_messages_written_count",
+                    "The number of marker messages written to the local topic")
+            .register();
+
+    private static final Counter receivedMarkerMessageCounter = Counter
+            .build("pulsar_broker_replication_marker_messages_received_count",
+                    "The number of marker messages received by the broker")
+            .labelNames("remote_cluster", "marker_type")
+            .register();
+
     public ReplicatedSubscriptionsController(PersistentTopic topic, String localCluster) {
         this.topic = topic;
         this.localCluster = localCluster;
@@ -85,20 +105,24 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
                         TimeUnit.MILLISECONDS);
     }
 
-    public void receivedReplicatedSubscriptionMarker(Position position, int markerType, ByteBuf payload) {
+    public void receivedReplicatedSubscriptionMarker(String remoteCluster, Position position, int markerType,
+                                                     ByteBuf payload) {
         MarkerType m = null;
 
         try {
             switch (markerType) {
             case MarkerType.REPLICATED_SUBSCRIPTION_SNAPSHOT_REQUEST_VALUE:
+                recordReceivedMarkerMessage(remoteCluster, REPLICATED_SUBSCRIPTION_SNAPSHOT_REQUEST);
                 receivedSnapshotRequest(Markers.parseReplicatedSubscriptionsSnapshotRequest(payload));
                 break;
 
             case MarkerType.REPLICATED_SUBSCRIPTION_SNAPSHOT_RESPONSE_VALUE:
+                recordReceivedMarkerMessage(remoteCluster, REPLICATED_SUBSCRIPTION_SNAPSHOT_RESPONSE);
                 receivedSnapshotResponse(position, Markers.parseReplicatedSubscriptionsSnapshotResponse(payload));
                 break;
 
             case MarkerType.REPLICATED_SUBSCRIPTION_UPDATE_VALUE:
+                recordReceivedMarkerMessage(remoteCluster, REPLICATED_SUBSCRIPTION_UPDATE);
                 receiveSubscriptionUpdated(Markers.parseReplicatedSubscriptionsUpdate(payload));
                 break;
 
@@ -203,6 +227,10 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
         }
     }
 
+    private void recordReceivedMarkerMessage(String remoteCluster, MarkerType markerType) {
+        receivedMarkerMessageCounter.labels(remoteCluster, markerType.name()).inc();
+    }
+
     private void startNewSnapshot() {
         cleanupTimedOutSnapshots();
 
@@ -235,6 +263,7 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
             log.debug("[{}] Starting snapshot creation.", topic.getName());
         }
 
+        snapshotOperationCounter.inc();
         pendingSnapshotsMetric.inc();
         ReplicatedSubscriptionsSnapshotBuilder builder = new ReplicatedSubscriptionsSnapshotBuilder(this,
                 topic.getReplicators().keys(), topic.getBrokerService().pulsar().getConfiguration(), Clock.systemUTC());
@@ -289,6 +318,10 @@ public class ReplicatedSubscriptionsController implements AutoCloseable, Topic.P
         // closed
         if (log.isDebugEnabled()) {
             log.debug("[{}] Published marker at {}:{}. Exception: {}", topic.getName(), ledgerId, entryId, e);
+        }
+
+        if (e != null) {
+            writtenMarkerMessageCounter.inc();
         }
 
         this.positionOfLastLocalMarker = new PositionImpl(ledgerId, entryId);


### PR DESCRIPTION
### Motivation

This PR introduces additional metrics for monitoring marker and snapshot processing within replicated subscriptions. These enhancements provide better visibility into the replication process, enabling improved debugging and performance analysis.

### Modifications

- Updated `PersistentReplicator` to pass the source cluster (`replicatedFrom`) when handling replicated subscription markers.
- Modified `PersistentTopic` to include `remoteCluster` in `receivedReplicatedSubscriptionMarker`.
- Adjusted `ReplicatedSubscriptionsController` to process the additional `remoteCluster` parameter for improved tracking.
- Introduced new metrics to track the processing of markers and snapshots within replicated subscriptions.
  - `pulsar_broker_replication_subscription_snapshot_operation_count`(from the pulsar 4.x): The number of snapshot operations attempted:
      ```
      # TYPE pulsar_broker_replication_subscription_snapshot_operation_count counter
      pulsar_broker_replication_subscription_snapshot_operation_count{cluster="standalone"} 32.0
      ```
  
  - `pulsar_broker_replication_marker_messages_written_count`: The number of marker messages written to the local topic:
     ```
     # TYPE pulsar_broker_replication_marker_messages_written_count counter
     pulsar_broker_replication_marker_messages_written_count{cluster="standalone"} 0.0
     ```
  - `pulsar_broker_replication_marker_messages_received_count`: The number of marker messages received by the broker:
     ```
     # TYPE pulsar_broker_replication_marker_messages_received_count counter
     ````

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->