### PR TITLE
[fix][broker] Fix deleting topic not delete the related topic policy and schema. (#21093)

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -1535,7 +1535,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
     public void testDeleteNamespace(NamespaceAttr namespaceAttr) throws Exception {
         // Set conf.
         internalCleanup();
-        conf.setTopicLevelPoliciesEnabled(true);
+        conf.setTopicLevelPoliciesEnabled(namespaceAttr.systemTopicEnabled);
         NamespaceAttr originalNamespaceAttr = markOriginalNamespaceAttr();
         setNamespaceAttr(namespaceAttr);
         setup();


### PR DESCRIPTION
### Modifications

When deleting the topic, delete the schema and topic policies even if the topic is not loaded.

(cherry picked from commit a1405ea006f175b1bd0b9d28b9444d592fb4a010)
Signed-off-by: Zixuan Liu <nodeces@gmail.com>
  
### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
