### PR TITLE
[improve][broker] Ensure topic creation and partition update before starting GEO

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentReplicator.java
@@ -30,6 +30,7 @@ import org.apache.pulsar.broker.service.AbstractReplicator;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.Replicator;
 import org.apache.pulsar.broker.service.persistent.PersistentReplicator;
+import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.impl.MessageImpl;
@@ -49,9 +50,10 @@ public class NonPersistentReplicator extends AbstractReplicator implements Repli
     private final NonPersistentReplicatorStatsImpl stats = new NonPersistentReplicatorStatsImpl();
 
     public NonPersistentReplicator(NonPersistentTopic topic, String localCluster, String remoteCluster,
-            BrokerService brokerService, PulsarClientImpl replicationClient) throws PulsarServerException {
+                                   BrokerService brokerService, PulsarClientImpl replicationClient,
+                                   PulsarAdmin replicationAdmin) throws PulsarServerException {
         super(topic, topic.getReplicatorPrefix(), localCluster, remoteCluster, brokerService,
-                replicationClient);
+                replicationClient, replicationAdmin);
 
         producerBuilder.blockIfQueueFull(false);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -54,6 +54,7 @@ import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.BrokerServiceException.TopicBusyException;
 import org.apache.pulsar.broker.service.Replicator;
 import org.apache.pulsar.broker.service.persistent.DispatchRateLimiter.Type;
+import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.Backoff;
@@ -116,10 +117,11 @@ public class PersistentReplicator extends AbstractReplicator
     private volatile boolean fetchSchemaInProgress = false;
 
     public PersistentReplicator(PersistentTopic topic, ManagedCursor cursor, String localCluster, String remoteCluster,
-                                BrokerService brokerService, PulsarClientImpl replicationClient)
+                                BrokerService brokerService, PulsarClientImpl replicationClient,
+                                PulsarAdmin replicationAdmin)
             throws PulsarServerException {
         super(topic, topic.getReplicatorPrefix(), localCluster, remoteCluster, brokerService,
-                replicationClient);
+                replicationClient, replicationAdmin);
         this.topic = topic;
         this.cursor = cursor;
         this.expiryMonitor = new PersistentMessageExpiryMonitor((PersistentTopic) localTopic,


### PR DESCRIPTION
### Motivation

In a GEO replication scenario, if the remote cluster does not have the replicated topic and the auto-creation type differs between the local and remote clusters, message replication may fail. To ensure seamless replication, the topic metadata must be properly synchronized across clusters.

### Modifications

- When both the local and remote partitioned topic metadata indicate `partitions=0`, this means the topic is non-partitioned. In this case, the local cluster sends a non-partitioned topic creation request to the remote cluster.

- If the local partitioned topic metadata has `partitions>0`, this means the topic is partitioned:
  - If the remote partitioned topic metadata has `partitions=0`, the local cluster sends a partitioned topic creation request to the remote cluster.
  - If the remote partitioned topic metadata has fewer partitions than the local cluster, the local cluster sends an update request to align the partition to the remote cluster.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->