### PR TITLE
[fix][broker] Add topic consistency check

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1151,17 +1151,20 @@ public class NamespaceService implements AutoCloseable {
      * Check topic exists( partitioned or non-partitioned ).
      */
     public CompletableFuture<TopicExistsInfo> checkTopicExists(TopicName topic) {
-        return pulsar.getBrokerService()
-            .fetchPartitionedTopicMetadataAsync(TopicName.get(topic.toString()))
-            .thenCompose(metadata -> {
-                if (metadata.partitions > 0) {
-                    return CompletableFuture.completedFuture(
-                            TopicExistsInfo.newPartitionedTopicExists(metadata.partitions));
-                }
-                return checkNonPartitionedTopicExists(topic)
-                    .thenApply(b -> b ? TopicExistsInfo.newNonPartitionedTopicExists()
-                            : TopicExistsInfo.newTopicNotExists());
-            });
+        // For non-persistent/persistent partitioned topic, which has metadata.
+        return pulsar.getBrokerService().fetchPartitionedTopicMetadataAsync(
+                        topic.isPartitioned() ? TopicName.get(topic.getPartitionedTopicName()) : topic)
+                .thenCompose(metadata -> {
+                    if (metadata.partitions > 0) {
+                        return CompletableFuture.completedFuture(
+                                topic.isPartitioned() ? TopicExistsInfo.newNonPartitionedTopicExists() :
+                                        TopicExistsInfo.newPartitionedTopicExists(metadata.partitions));
+                    }
+                    // Direct query the single topic.
+                    return checkNonPartitionedTopicExists(topic).thenApply(
+                            b -> b ? TopicExistsInfo.newNonPartitionedTopicExists() :
+                                    TopicExistsInfo.newTopicNotExists());
+                });
     }
 
     /***

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1182,12 +1182,12 @@ public class NamespaceService implements AutoCloseable {
      */
     public CompletableFuture<Boolean> checkNonPersistentNonPartitionedTopicExists(String topic) {
         TopicName topicName = TopicName.get(topic);
-        // "non-partitioned & non-persistent" topics only exist on the owner broker.
+        // "non-partitioned & non-persistent" topics only exist on the cache of the owner broker.
         return checkTopicOwnership(TopicName.get(topic)).thenCompose(isOwned -> {
             // The current broker is the owner.
             if (isOwned) {
                CompletableFuture<Optional<Topic>> nonPersistentTopicFuture = pulsar.getBrokerService()
-                       .getTopic(topic, false);
+                       .getTopics().get(topic);
                if (nonPersistentTopicFuture != null) {
                    return nonPersistentTopicFuture.thenApply(Optional::isPresent);
                } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -972,6 +972,64 @@ public class BrokerService implements Closeable {
     }
 
     /**
+     * Validates that the topic is consistent with its partition metadata.
+     *
+     * This method ensures the topic (partitioned or non-partitioned) correctly
+     * matches the actual partitions in the metadata. Inconsistencies typically
+     * indicate configuration issues or metadata synchronization problems.
+     *
+     * This validation is particularly important in geo-replicated environments where
+     * topic metadata may not be fully synchronized across all regions, potentially
+     * leading to access errors if not properly handled.
+     *
+     * @param topicName The topic name to validate
+     * @param metadata  The partition metadata retrieved for this topic
+     * @return CompletableFuture that completes normally if validation passes, or
+     * completes exceptionally with NotAllowedException if validation fails
+     */
+    private CompletableFuture<Void> validateTopicConsistency(TopicName topicName, PartitionedTopicMetadata metadata) {
+        if (NamespaceService.isHeartbeatNamespace(topicName.getNamespaceObject())) {
+            // Skip validation for heartbeat namespace.
+            return CompletableFuture.completedFuture(null);
+        }
+
+        if (topicName.isPartitioned()) {
+            if (metadata.partitions == 0) {
+                // Edge case: When a complete partitioned topic name is provided but metadata shows 0 partitions.
+                // This indicates that the partitioned topic metadata doesn't exist.
+                //
+                // Resolution options:
+                // 1. Creates the partitioned topic via admin API.
+                // 2. Uses the basic topic name and then rely on auto-creation if enabled.
+                return FutureUtil.failedFuture(
+                        new BrokerServiceException.NotAllowedException(
+                                "Partition metadata not found for the partitioned topic: " + topicName));
+            }
+            if (topicName.getPartitionIndex() >= metadata.partitions) {
+                final String errorMsg =
+                        String.format(
+                                "Illegal topic partition name %s with max allowed "
+                                        + "%d partitions", topicName,
+                                metadata.partitions);
+                log.warn(errorMsg);
+                return FutureUtil.failedFuture(
+                        new BrokerServiceException.NotAllowedException(errorMsg));
+            }
+        } else if (metadata.partitions > 0) {
+            // Edge case: Non-partitioned topic name was provided, but metadata indicates this is actually a partitioned
+            // topic (partitions > 0).
+            //
+            // Resolution: Must use the complete partitioned topic name('topic-name-partition-N').
+            //
+            // This ensures proper routing to the specific partition and prevents ambiguity in topic addressing.
+            return FutureUtil.failedFuture(new BrokerServiceException.NotAllowedException(
+                    "Found partitioned metadata for non-partitioned topic: " + topicName));
+        }
+
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
      * Retrieves or creates a topic based on the specified parameters.
      * 0. If disable PersistentTopics or NonPersistentTopics, it will return a failed future with NotAllowedException.
      * 1. If topic future exists in the cache returned directly regardless of whether it fails or timeout.
@@ -1017,30 +1075,9 @@ public class BrokerService implements Closeable {
                         throw FutureUtil.wrapToCompletionException(new ServiceUnitNotReadyException(errorInfo));
                     }).thenCompose(optionalTopicPolicies -> {
                         final TopicPolicies topicPolicies = optionalTopicPolicies.orElse(null);
-                        if (topicName.isPartitioned()) {
-                            final TopicName topicNameEntity = TopicName.get(topicName.getPartitionedTopicName());
-                            return fetchPartitionedTopicMetadataAsync(topicNameEntity)
-                                    .thenCompose((metadata) -> {
-                                        // Allow crate non-partitioned persistent topic that name includes
-                                        // `partition`
-                                        if (metadata.partitions == 0
-                                                || topicName.getPartitionIndex() < metadata.partitions) {
-                                            return topics.computeIfAbsent(topicName.toString(), (tpName) ->
-                                                    loadOrCreatePersistentTopic(tpName,
-                                                            createIfMissing, properties, topicPolicies));
-                                        } else {
-                                            final String errorMsg =
-                                                    String.format("Illegal topic partition name %s with max allowed "
-                                                            + "%d partitions", topicName, metadata.partitions);
-                                            log.warn(errorMsg);
-                                            return FutureUtil.failedFuture(
-                                                    new BrokerServiceException.NotAllowedException(errorMsg));
-                                        }
-                                    });
-                        } else {
-                            return topics.computeIfAbsent(topicName.toString(), (tpName) ->
-                                    loadOrCreatePersistentTopic(tpName, createIfMissing, properties, topicPolicies));
-                        }
+                        return topics.computeIfAbsent(topicName.toString(),
+                                (tpName) -> loadOrCreatePersistentTopic(tpName, createIfMissing, properties,
+                                        topicPolicies));
                     });
                 });
             } else {
@@ -1054,29 +1091,10 @@ public class BrokerService implements Closeable {
                 if (!topics.containsKey(topicName.toString())) {
                     topicEventsDispatcher.notify(topicName.toString(), TopicEvent.LOAD, EventStage.BEFORE);
                 }
-                if (topicName.isPartitioned()) {
-                    final TopicName partitionedTopicName = TopicName.get(topicName.getPartitionedTopicName());
-                    return this.fetchPartitionedTopicMetadataAsync(partitionedTopicName).thenCompose((metadata) -> {
-                        if (topicName.getPartitionIndex() < metadata.partitions) {
-                            return topics.computeIfAbsent(topicName.toString(), (name) -> {
-                                topicEventsDispatcher
-                                        .notify(topicName.toString(), TopicEvent.CREATE, EventStage.BEFORE);
-
-                                CompletableFuture<Optional<Topic>> res = createNonPersistentTopic(name);
-
-                                CompletableFuture<Optional<Topic>> eventFuture = topicEventsDispatcher
-                                        .notifyOnCompletion(res, topicName.toString(), TopicEvent.CREATE);
-                                topicEventsDispatcher
-                                        .notifyOnCompletion(eventFuture, topicName.toString(), TopicEvent.LOAD);
-                                return res;
-                            });
-                        }
-                        topicEventsDispatcher.notify(topicName.toString(), TopicEvent.LOAD, EventStage.FAILURE);
-                        return CompletableFuture.completedFuture(Optional.empty());
-                    });
-                } else if (createIfMissing) {
+                if (topicName.isPartitioned() || createIfMissing) {
                     return topics.computeIfAbsent(topicName.toString(), (name) -> {
-                        topicEventsDispatcher.notify(topicName.toString(), TopicEvent.CREATE, EventStage.BEFORE);
+                        topicEventsDispatcher
+                                .notify(topicName.toString(), TopicEvent.CREATE, EventStage.BEFORE);
 
                         CompletableFuture<Optional<Topic>> res = createNonPersistentTopic(name);
 
@@ -1264,7 +1282,13 @@ public class BrokerService implements Closeable {
         final long topicCreateTimeMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
         NonPersistentTopic nonPersistentTopic = new NonPersistentTopic(topic, this);
         CompletableFuture<Void> isOwner = checkTopicNsOwnership(topic);
-        isOwner.thenRun(() -> {
+        TopicName topicName = TopicName.get(topic);
+        TopicName baseTopicName =
+                topicName.isPartitioned() ? TopicName.get(topicName.getPartitionedTopicName()) : topicName;
+        isOwner.thenCompose(__ -> fetchPartitionedTopicMetadataAsync(baseTopicName))
+                .thenCompose(
+                        (partitionedTopicMetadata) -> validateTopicConsistency(topicName, partitionedTopicMetadata))
+                .thenRun(() -> {
             nonPersistentTopic.initialize()
                     .thenCompose(__ -> nonPersistentTopic.checkReplication())
                     .thenRun(() -> {
@@ -1282,17 +1306,7 @@ public class BrokerService implements Closeable {
                 return null;
             });
         }).exceptionally(e -> {
-            log.warn("CheckTopicNsOwnership fail when createNonPersistentTopic! {}", topic, e.getCause());
-            // CheckTopicNsOwnership fail dont create nonPersistentTopic, when topic do lookup will find the correct
-            // broker. When client get non-persistent-partitioned topic
-            // metadata will the non-persistent-topic will be created.
-            // so we should add checkTopicNsOwnership logic otherwise the topic will be created
-            // if it dont own by this broker,we should return success
-            // otherwise it will keep retrying getPartitionedTopicMetadata
-            topicFuture.complete(Optional.of(nonPersistentTopic));
-            // after get metadata return success, we should delete this topic from this broker, because this topic not
-            // owner by this broker and it don't initialize and checkReplication
-            pulsar.getExecutor().execute(() -> topics.remove(topic, topicFuture));
+            topicFuture.completeExceptionally(FutureUtil.unwrapCompletionException(e));
             return null;
         });
 
@@ -1585,7 +1599,12 @@ public class BrokerService implements Closeable {
                 ? checkMaxTopicsPerNamespace(topicName, 1)
                 : CompletableFuture.completedFuture(null);
 
-        maxTopicsCheck.thenCompose(__ -> getManagedLedgerConfig(topicName)).thenAccept(managedLedgerConfig -> {
+        TopicName baseTopicName =
+                topicName.isPartitioned() ? TopicName.get(topicName.getPartitionedTopicName()) : topicName;
+        maxTopicsCheck.thenCompose(__ -> fetchPartitionedTopicMetadataAsync(baseTopicName))
+                .thenCompose(partitionedTopicMetadata -> validateTopicConsistency(topicName, partitionedTopicMetadata))
+                .thenCompose(__ -> getManagedLedgerConfig(topicName, topicPolicies))
+        .thenAccept(managedLedgerConfig -> {
             if (isBrokerEntryMetadataEnabled() || isBrokerPayloadProcessorEnabled()) {
                 // init managedLedger interceptor
                 Set<BrokerEntryMetadataInterceptor> interceptors = new HashSet<>();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -2544,10 +2544,8 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testPersistentTopicsExpireMessagesInvalidPartitionIndex() throws Exception {
-        // Force to create a topic
-        publishMessagesOnPersistentTopic("persistent://prop-xyz/ns1/ds2-partition-2", 0);
-        assertEquals(admin.topics().getList("prop-xyz/ns1"),
-                Lists.newArrayList("persistent://prop-xyz/ns1/ds2-partition-2"));
+        // Create a topic
+        admin.topics().createPartitionedTopic("persistent://prop-xyz/ns1/ds2", 3);
 
         // create consumer and subscription
         @Cleanup

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicAutoCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/TopicAutoCreationTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import java.net.InetSocketAddress;
 import java.util.List;
@@ -41,6 +42,7 @@ import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.PulsarClientException.NotAllowedException;
 import org.apache.pulsar.client.impl.LookupService;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
@@ -101,16 +103,14 @@ public class TopicAutoCreationTest extends ProducerConsumerBase {
 
         final String partition = "persistent://" + namespaceName + "/test-partitioned-topi-auto-creation-partition-0";
 
-        producer = pulsarClient.newProducer()
-                .topic(partition)
-                .create();
-
-        partitionedTopics = admin.topics().getPartitionedTopicList(namespaceName);
-        topics = admin.topics().getList(namespaceName);
-        assertEquals(partitionedTopics.size(), 0);
-        assertEquals(topics.size(), 1);
-
-        producer.close();
+        // The Pulsar doesn't automatically create the metadata for the single partition, so the producer creation
+        // will fail.
+        assertThrows(NotAllowedException.class, () -> {
+            @Cleanup
+            Producer<byte[]> ignored = pulsarClient.newProducer()
+                    .topic(partition)
+                    .create();
+        });
     }
 
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ExclusiveProducerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ExclusiveProducerTest.java
@@ -19,20 +19,19 @@
 package org.apache.pulsar.broker.service;
 
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.fail;
-
+import io.netty.util.HashedWheelTimer;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-
-import io.netty.util.HashedWheelTimer;
 import lombok.Cleanup;
-
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerAccessMode;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException.ProducerBusyException;
 import org.apache.pulsar.client.api.PulsarClientException.ProducerFencedException;
+import org.apache.pulsar.client.api.PulsarClientException.TimeoutException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.common.naming.TopicName;
@@ -225,6 +224,7 @@ public class ExclusiveProducerTest extends BrokerTestBase {
     public void topicDeleted(String ignored, boolean partitioned) throws Exception {
         String topic = newTopic("persistent", partitioned);
 
+        @Cleanup
         Producer<String> p1 = pulsarClient.newProducer(Schema.STRING)
                 .topic(topic)
                 .accessMode(ProducerAccessMode.Exclusive)
@@ -238,8 +238,14 @@ public class ExclusiveProducerTest extends BrokerTestBase {
             admin.topics().delete(topic, true);
         }
 
-        // The producer should be able to publish again on the topic
-        p1.send("msg-2");
+        if (!partitioned) {
+            // The producer should be able to publish again on the topic
+            p1.send("msg-2");
+        } else {
+            // The partitioned topic is deleted, the producer should not be able to publish again on the topic.
+            // Partitioned metadata is required to publish messages to the topic.
+            assertThrows(TimeoutException.class, () -> p1.send("msg-2"));
+        }
     }
 
     @Test(dataProvider = "topics")

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -65,7 +65,7 @@ import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.PulsarService;
-import org.apache.pulsar.broker.service.BrokerServiceException.NamingException;
+import org.apache.pulsar.broker.service.BrokerServiceException.NotAllowedException;
 import org.apache.pulsar.broker.service.persistent.PersistentReplicator;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdmin;
@@ -1243,7 +1243,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
             if (!isPartitionedTopic) {
                 fail("Topic creation should not fail without any partitioned topic");
             }
-            assertTrue(e.getCause() instanceof NamingException);
+            assertTrue(e.getCause() instanceof NotAllowedException);
         }
 
         // non-persistent topic test
@@ -1256,7 +1256,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
             if (!isPartitionedTopic) {
                 fail("Topic creation should not fail without any partitioned topic");
             }
-            assertTrue(e.getCause() instanceof NamingException);
+            assertTrue(e.getCause() instanceof NotAllowedException);
         }
 
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerCreationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ConsumerCreationTest.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.client.api;
+
+import static org.testng.Assert.assertThrows;
+import lombok.Cleanup;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.PulsarClientException.NotAllowedException;
+import org.apache.pulsar.common.naming.TopicDomain;
+import org.apache.pulsar.common.naming.TopicName;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+@Test(groups = "broker-api")
+public class ConsumerCreationTest extends ProducerConsumerBase {
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @DataProvider(name = "topicDomainProvider")
+    public Object[][] topicDomainProvider() {
+        return new Object[][]{
+                {TopicDomain.persistent},
+                {TopicDomain.non_persistent}
+        };
+    }
+
+    @Test(dataProvider = "topicDomainProvider")
+    public void testCreateConsumerWhenTopicTypeMismatch(TopicDomain domain)
+            throws PulsarAdminException, PulsarClientException {
+        String nonPartitionedTopic =
+                TopicName.get(domain.value(), "public", "default",
+                                "testCreateConsumerWhenTopicTypeMismatch-nonPartitionedTopic")
+                        .toString();
+        admin.topics().createNonPartitionedTopic(nonPartitionedTopic);
+
+        // Topic type is non-partitioned, Trying to create consumer on partitioned topic.
+        assertThrows(NotAllowedException.class, () -> {
+            @Cleanup
+            Consumer<byte[]> ignored =
+                    pulsarClient.newConsumer().topic(TopicName.get(nonPartitionedTopic).getPartition(2).toString())
+                            .subscriptionName("my-sub").subscribe();
+        });
+
+        // Topic type is partitioned, Trying to create consumer on non-partitioned topic.
+        String partitionedTopic = TopicName.get(domain.value(), "public", "default",
+                        "testCreateConsumerWhenTopicTypeMismatch-partitionedTopic")
+                .toString();
+        admin.topics().createPartitionedTopic(partitionedTopic, 3);
+
+        // Works fine because the lookup can help our to find the correct topic.
+        {
+            @Cleanup
+            Consumer<byte[]> ignored =
+                    pulsarClient.newConsumer().topic(TopicName.get(partitionedTopic).getPartition(2).toString())
+                            .subscriptionName("my-sub").subscribe();
+        }
+
+        // Partition index is out of range.
+        assertThrows(NotAllowedException.class, () -> {
+            @Cleanup
+            Consumer<byte[]> ignored =
+                    pulsarClient.newConsumer().topic(TopicName.get(partitionedTopic).getPartition(100).toString())
+                            .subscriptionName("my-sub").subscribe();
+        });
+    }
+}


### PR DESCRIPTION
### Motivation

In Apache Pulsar, clients can produce or consume messages using a fully qualified partition topic name (`public/default/test-partitioned-topic-partition-N`). However, if the topic metadata does not exist and `allowAutoTopicCreationType=non-partitioned` is enabled, Pulsar automatically creates the topic as non-partitioned. This leads to inconsistencies when listing topics, as the expected partitioned topic structure is not maintained.

This issue is especially prevalent in geo-replicated environments, where topic metadata may not be fully synchronized across all regions. Currently, Pulsar lacks validation to ensure that the topic type (partitioned or non-partitioned) matches the actual partition metadata.

### Modifications

- Added a topic consistency check:
  - **For non-partitioned topic**: If partition metadata exists (which shouldn't be there), the broker will reject message produce and consume operations.
  - **For partitioned topic**: If partition metadata is missing (which should be there), the broker will reject message produce and consume operations.
- Fixed affected tests to align with the new validation logic.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
