### PR TITLE
[feat][broker] Add replicator dispatch rate for resource group based on cluster

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/ResourceGroupResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/ResourceGroupResources.java
@@ -64,6 +64,11 @@ public class ResourceGroupResources extends BaseResources<ResourceGroup> {
         set(joinPath(BASE_PATH, resourceGroupName), modifyFunction);
     }
 
+    public CompletableFuture<Void> updateResourceGroupAsync(String resourceGroupName,
+                                                            Function<ResourceGroup, ResourceGroup> modifyFunction) {
+        return setAsync(joinPath(BASE_PATH, resourceGroupName), modifyFunction);
+    }
+
     public List<String> listResourceGroups() throws MetadataStoreException {
         return getChildren(BASE_PATH);
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/ResourceGroups.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/ResourceGroups.java
@@ -17,6 +17,7 @@
  * under the License.
  */
 package org.apache.pulsar.broker.admin.v2;
+
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -26,12 +27,18 @@ import java.util.List;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import org.apache.pulsar.broker.admin.impl.ResourceGroupsBase;
+import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.policies.data.ResourceGroup;
 
 @Path("/resourcegroups")
@@ -77,6 +84,54 @@ public class ResourceGroups extends ResourceGroupsBase {
             @ApiResponse(code = 409, message = "ResourceGroup is in use")})
     public void deleteResourceGroup(@PathParam("resourcegroup") String resourcegroup) {
         internalDeleteResourceGroup(resourcegroup);
+    }
+
+    @POST
+    @Path("/{resourcegroup}/replicatorDispatchRate")
+    @ApiOperation(value = "Set replicator dispatch-rate throttling for a resourcegroup")
+    @ApiResponses(value = {
+            @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "ResourceGroup doesn't exist")})
+    public void setReplicatorDispatchRate(@Suspended AsyncResponse asyncResponse,
+                                          @PathParam("resourcegroup") String resourcegroup,
+                                          @QueryParam("cluster") String remoteCluster,
+                                          DispatchRate dispatchRate) {
+        internalSetReplicatorDispatchRate(resourcegroup, remoteCluster, dispatchRate)
+                .thenAccept((__) -> asyncResponse.resume(Response.noContent().build()))
+                .exceptionally(ex -> {
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+    }
+
+    @DELETE
+    @Path("/{resourcegroup}/replicatorDispatchRate")
+    @ApiOperation(value = "Delete replicator dispatch-rate throttling for a resourcegroup")
+    @ApiResponses(value = {
+            @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "ResourceGroup doesn't exist")})
+    public void removeReplicatorDispatchRate(@Suspended AsyncResponse asyncResponse,
+                                             @PathParam("resourcegroup") String resourcegroup,
+                                             @QueryParam("cluster") String remoteCluster,
+                                             DispatchRate dispatchRate) {
+        setReplicatorDispatchRate(asyncResponse, resourcegroup, remoteCluster, null);
+    }
+
+    @GET
+    @Path("/{resourcegroup}/replicatorDispatchRate")
+    @ApiOperation(value = "Get replicator dispatch-rate throttling for a resourcegroup")
+    @ApiResponses(value = {
+            @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "ResourceGroup doesn't exist")})
+    public void getReplicatorDispatchRate(@Suspended AsyncResponse asyncResponse,
+                                          @PathParam("resourcegroup") String resourcegroup,
+                                          @QueryParam("cluster") String remoteCluster) {
+        internalGetReplicatorDispatchRate(resourcegroup, remoteCluster)
+                .thenAccept(asyncResponse::resume)
+                .exceptionally(ex -> {
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
     }
 }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroup.java
@@ -189,7 +189,7 @@ public class ResourceGroup {
     }
 
     private ResourceGroupDispatchLimiter updateReplicatorLimiter(String key, ResourceGroupDispatchLimiter oldLimiter,
-                                                                 org.apache.pulsar.common.policies.data.ResourceGroup rgConfig) {
+                                                 org.apache.pulsar.common.policies.data.ResourceGroup rgConfig) {
         DispatchRate dispatchRate = rgConfig.getReplicatorDispatchRate().get(key);
         if (dispatchRate == null) {
             // Specific rate-limiter for this cluster is removed in the new config.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroup.java
@@ -23,11 +23,14 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.val;
@@ -36,6 +39,7 @@ import org.apache.pulsar.broker.resourcegroup.ResourceGroupService.ResourceGroup
 import org.apache.pulsar.broker.service.resource.usage.NetworkUsage;
 import org.apache.pulsar.broker.service.resource.usage.ResourceUsage;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,14 +124,18 @@ public class ResourceGroup {
         this.ruConsumer = rgConsumer;
     }
 
+
     // copy ctor: note does shallow copy.
     // The envisioned usage is for display of an RG's state, without scope for direct update.
     public ResourceGroup(ResourceGroup other) {
         this.resourceGroupName = other.resourceGroupName;
         this.rgs = other.rgs;
+        this.rgConfig = other.rgConfig;
         this.resourceGroupPublishLimiter = other.resourceGroupPublishLimiter;
         this.resourceGroupReplicationDispatchLimiter = other.resourceGroupReplicationDispatchLimiter;
         this.resourceGroupDispatchLimiter = other.resourceGroupDispatchLimiter;
+        this.replicatorDispatchRateLimiterMap = other.replicatorDispatchRateLimiterMap;
+        this.replicatorDispatchRateLimiterConsumerMap = other.replicatorDispatchRateLimiterConsumerMap;
         this.setResourceGroupMonitoringClassFields();
 
         // ToDo: copy the monitoring class fields, and ruPublisher/ruConsumer from other, if required.
@@ -167,9 +175,87 @@ public class ResourceGroup {
         pubBmc.messages = rgConfig.getPublishRateInMsgs();
         pubBmc.bytes = rgConfig.getPublishRateInBytes();
         this.resourceGroupPublishLimiter.update(pubBmc);
+        updateReplicationDispatchLimiters(rgConfig);
+        ResourceGroupRateLimiterManager.updateDispatchRateLimiter(resourceGroupDispatchLimiter, rgConfig);
+    }
+
+    private void updateReplicationDispatchLimiters(org.apache.pulsar.common.policies.data.ResourceGroup rgConfig) {
         ResourceGroupRateLimiterManager
                 .updateReplicationDispatchRateLimiter(resourceGroupReplicationDispatchLimiter, rgConfig);
-        ResourceGroupRateLimiterManager.updateDispatchRateLimiter(resourceGroupDispatchLimiter, rgConfig);
+        replicatorDispatchRateLimiterMap.forEach((key, oldLimiter) ->
+                replicatorDispatchRateLimiterMap.computeIfPresent(key,
+                        (k, old) -> updateReplicatorLimiter(k, old, rgConfig))
+        );
+    }
+
+    private ResourceGroupDispatchLimiter updateReplicatorLimiter(String key, ResourceGroupDispatchLimiter oldLimiter,
+                                                                 org.apache.pulsar.common.policies.data.ResourceGroup rgConfig) {
+        DispatchRate dispatchRate = rgConfig.getReplicatorDispatchRate().get(key);
+        if (dispatchRate == null) {
+            // Specific rate-limiter for this cluster is removed in the new config.
+            // use the default rate-limiter, notify the rate-limiter consumers.
+            if (oldLimiter != resourceGroupReplicationDispatchLimiter) {
+                notifyReplicatorDispatchRateLimiterConsumer(key, resourceGroupReplicationDispatchLimiter);
+                return resourceGroupReplicationDispatchLimiter;
+            }
+        } else if (oldLimiter == resourceGroupReplicationDispatchLimiter) {
+            // Specific rate-limiter for this cluster is provided in the new config.
+            // When rate-limiter is default, new a rate-limiter.
+            ResourceGroupDispatchLimiter newLimiter = createNewReplicatorLimiter(key);
+            notifyReplicatorDispatchRateLimiterConsumer(key, newLimiter);
+            return newLimiter;
+        } else {
+            oldLimiter.update(dispatchRate.getDispatchThrottlingRateInMsg(),
+                    dispatchRate.getDispatchThrottlingRateInByte());
+        }
+        return oldLimiter;
+    }
+
+    private String getReplicatorDispatchRateLimiterKey(String remoteCluster) {
+        return String.format("%s->%s", rgs.getPulsar().getConfiguration().getClusterName(), remoteCluster);
+    }
+
+    private ResourceGroupDispatchLimiter createNewReplicatorLimiter(String key) {
+        return Optional.ofNullable(rgConfig.getReplicatorDispatchRate().get(key))
+                .map(dispatchRate -> ResourceGroupRateLimiterManager.newReplicationDispatchRateLimiter(
+                        rgs.getPulsar().getExecutor(),
+                        dispatchRate.getDispatchThrottlingRateInMsg(),
+                        dispatchRate.getDispatchThrottlingRateInByte()))
+                .orElse(resourceGroupReplicationDispatchLimiter);
+    }
+
+    private void notifyReplicatorDispatchRateLimiterConsumer(
+            String key, ResourceGroupDispatchLimiter limiter) {
+        replicatorDispatchRateLimiterConsumerMap.computeIfPresent(key, (__, consumerSet) -> {
+            consumerSet.forEach(c -> c.accept(limiter));
+            return consumerSet;
+        });
+    }
+
+    public void registerReplicatorDispatchRateLimiter(String remoteCluster,
+                                                      Consumer<ResourceGroupDispatchLimiter> consumer) {
+        String key = getReplicatorDispatchRateLimiterKey(remoteCluster);
+        ResourceGroupDispatchLimiter limiter =
+                replicatorDispatchRateLimiterMap.computeIfAbsent(key, __ -> createNewReplicatorLimiter(key));
+        consumer.accept(limiter);
+        // Must use compute instead of computeIfAbsent to avoid the notifyReplicatorDispatchRateLimiterConsumer
+        // concurrent access.
+        replicatorDispatchRateLimiterConsumerMap.compute(key, (__, old) -> {
+            if (old == null) {
+                old = ConcurrentHashMap.newKeySet();
+            }
+            old.add(consumer);
+            return old;
+        });
+    }
+
+    public void unregisterReplicatorDispatchRateLimiter(String remoteCluster,
+                                                        Consumer<ResourceGroupDispatchLimiter> consumer) {
+        String key = getReplicatorDispatchRateLimiterKey(remoteCluster);
+        replicatorDispatchRateLimiterConsumerMap.computeIfPresent(key, (__, old) -> {
+            old.remove(consumer);
+            return old;
+        });
     }
 
     protected long getResourceGroupNumOfNSRefs() {
@@ -609,6 +695,7 @@ public class ResourceGroup {
     }
 
     private void setResourceGroupConfigParameters(org.apache.pulsar.common.policies.data.ResourceGroup rgConfig) {
+        this.rgConfig = rgConfig;
         int idx;
 
         idx = ResourceGroupMonitoringClass.Publish.ordinal();
@@ -716,12 +803,18 @@ public class ResourceGroup {
             .labelNames(resourceGroupMontoringclassLabels)
             .register();
 
+    private org.apache.pulsar.common.policies.data.ResourceGroup rgConfig;
+
     // Publish rate limiter for the resource group
     @Getter
     protected ResourceGroupPublishLimiter resourceGroupPublishLimiter;
 
-    @Getter
-    protected ResourceGroupDispatchLimiter resourceGroupReplicationDispatchLimiter;
+    private final ResourceGroupDispatchLimiter resourceGroupReplicationDispatchLimiter;
+
+    private Map<String, ResourceGroupDispatchLimiter> replicatorDispatchRateLimiterMap =
+            new ConcurrentHashMap<>();
+    private Map<String, Set<Consumer<ResourceGroupDispatchLimiter>>> replicatorDispatchRateLimiterConsumerMap =
+            new ConcurrentHashMap<>();
 
     @Getter
     protected ResourceGroupDispatchLimiter resourceGroupDispatchLimiter;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupRateLimiterManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupRateLimiterManager.java
@@ -29,6 +29,11 @@ public class ResourceGroupRateLimiterManager {
             ScheduledExecutorService executorService) {
         long msgs = Optional.ofNullable(resourceGroup.getReplicationDispatchRateInMsgs()).orElse(-1L);
         long bytes = Optional.ofNullable(resourceGroup.getReplicationDispatchRateInBytes()).orElse(-1L);
+        return newReplicationDispatchRateLimiter(executorService, msgs, bytes);
+    }
+
+    static ResourceGroupDispatchLimiter newReplicationDispatchRateLimiter(ScheduledExecutorService executorService,
+                                                                          long msgs, long bytes) {
         return new ResourceGroupDispatchLimiter(executorService, msgs, bytes);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupRateLimiterManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/resourcegroup/ResourceGroupRateLimiterManagerTest.java
@@ -106,4 +106,37 @@ public class ResourceGroupRateLimiterManagerTest {
         assertEquals(resourceGroupDispatchLimiter.getAvailableDispatchRateLimitOnMsg(), quota.messages);
         assertEquals(resourceGroupDispatchLimiter.getDispatchRateOnMsg(), quota.messages);
     }
+
+    @Test
+    public void newReplicationDispatchRateLimiterWithValidData() {
+        @Cleanup(value = "shutdown")
+        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+        @Cleanup
+        ResourceGroupDispatchLimiter limiter =
+                ResourceGroupRateLimiterManager.newReplicationDispatchRateLimiter(executorService, 100L, 1000L);
+        assertEquals(limiter.getDispatchRateOnMsg(), 100L);
+        assertEquals(limiter.getDispatchRateOnByte(), 1000L);
+    }
+
+    @Test
+    public void newReplicationDispatchRateLimiterWithZeroValues() {
+        @Cleanup(value = "shutdown")
+        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+        @Cleanup
+        ResourceGroupDispatchLimiter limiter =
+                ResourceGroupRateLimiterManager.newReplicationDispatchRateLimiter(executorService, 0L, 0L);
+        assertEquals(limiter.getDispatchRateOnMsg(), -1L);
+        assertEquals(limiter.getDispatchRateOnByte(), -1L);
+    }
+
+    @Test
+    public void newReplicationDispatchRateLimiterWithNegativeValues() {
+        @Cleanup(value = "shutdown")
+        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+        @Cleanup
+        ResourceGroupDispatchLimiter limiter =
+                ResourceGroupRateLimiterManager.newReplicationDispatchRateLimiter(executorService, -1L, -1L);
+        assertEquals(limiter.getDispatchRateOnMsg(), -1L);
+        assertEquals(limiter.getDispatchRateOnByte(), -1L);
+    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorRateLimiterTest.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Sets;
 import java.lang.reflect.Method;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Cleanup;
@@ -640,6 +641,77 @@ public class ReplicatorRateLimiterTest extends ReplicatorTestBase {
         }
 
         Assert.assertTrue(totalReceived.get() < messageRate * 2);
+    }
+
+    @Test
+    public void testLoadResourceGroupReplicatorRateLimiter() throws Exception {
+        final String namespace = "pulsar/replicatormsg-" + System.currentTimeMillis();
+        final String topicName = "persistent://" + namespace + "/" + UUID.randomUUID();
+
+        admin1.namespaces().createNamespace(namespace);
+        // 0. set 2 clusters, there will be 1 replicator in each topic
+        admin1.namespaces().setNamespaceReplicationClusters(namespace, Sets.newHashSet("r1", "r2"));
+
+        // ResourceGroupDispatchRateLimiter
+        long messageRate = 100;
+        long byteRate = 500000;
+        String resourceGroupName = UUID.randomUUID().toString();
+        ResourceGroup resourceGroup = new ResourceGroup();
+        resourceGroup.setReplicationDispatchRateInMsgs(messageRate);
+        resourceGroup.setReplicationDispatchRateInBytes(byteRate);
+        admin1.resourcegroups().createResourceGroup(resourceGroupName, resourceGroup);
+        Awaitility.await().untilAsserted(() -> assertNotNull(admin1.resourcegroups()
+                .getResourceGroup(resourceGroupName)));
+        admin1.namespaces().setNamespaceResourceGroup(namespace, resourceGroupName);
+
+        @Cleanup
+        PulsarClient client1 = PulsarClient.builder().serviceUrl(url1.toString()).statsInterval(0, TimeUnit.SECONDS)
+                .build();
+
+        @Cleanup
+        Producer<byte[]> producer = client1.newProducer().topic(topicName)
+                .enableBatching(false)
+                .messageRoutingMode(MessageRoutingMode.SinglePartition)
+                .create();
+        producer.send(new byte[1]);
+
+        CompletableFuture<Optional<Topic>> topicIfExists = pulsar1.getBrokerService().getTopicIfExists(topicName);
+        assertThat(topicIfExists).succeedsWithin(3, TimeUnit.SECONDS);
+        Optional<Topic> topicOptional = topicIfExists.get();
+        assertTrue(topicOptional.isPresent());
+        PersistentTopic persistentTopic = (PersistentTopic) topicOptional.get();
+
+        Replicator r2Replicator = persistentTopic.getReplicators().get("r2");
+        assertNotNull(r2Replicator);
+        Optional<ResourceGroupDispatchLimiter> resourceGroupDispatchRateLimiter =
+                r2Replicator.getResourceGroupDispatchRateLimiter();
+        assertTrue(resourceGroupDispatchRateLimiter.isPresent());
+        assertEquals(resourceGroupDispatchRateLimiter.get().getDispatchRateOnMsg(), messageRate);
+        assertEquals(resourceGroupDispatchRateLimiter.get().getDispatchRateOnByte(), byteRate);
+
+        // Set up rate limiter for r1 -> r2 channel.
+        long messageRateBetweenR1AndR2 = 1000;
+        long byteRateBetweenR1AndR2 = 5000000;
+        admin1.resourcegroups().setReplicatorDispatchRate(resourceGroupName, "r2",
+                DispatchRate.builder()
+                        .dispatchThrottlingRateInByte(byteRateBetweenR1AndR2)
+                        .dispatchThrottlingRateInMsg((int) messageRateBetweenR1AndR2)
+                        .build());
+        Awaitility.await().untilAsserted(() -> {
+            Optional<ResourceGroupDispatchLimiter> rateLimiter = r2Replicator.getResourceGroupDispatchRateLimiter();
+            assertTrue(rateLimiter.isPresent());
+            assertEquals(rateLimiter.get().getDispatchRateOnMsg(), messageRateBetweenR1AndR2);
+            assertEquals(rateLimiter.get().getDispatchRateOnByte(), byteRateBetweenR1AndR2);
+        });
+
+        // Remove rate limiter for r1 -> r2 channel, and then use the default rate limiter.
+        admin1.resourcegroups().removeReplicatorDispatchRate(resourceGroupName, "r2");
+        Awaitility.await().untilAsserted(() -> {
+            Optional<ResourceGroupDispatchLimiter> rateLimiter = r2Replicator.getResourceGroupDispatchRateLimiter();
+            assertTrue(rateLimiter.isPresent());
+            assertEquals(rateLimiter.get().getDispatchRateOnMsg(), messageRate);
+            assertEquals(rateLimiter.get().getDispatchRateOnByte(), byteRate);
+        });
     }
 
     @Test

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/ResourceGroups.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/ResourceGroups.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.client.admin;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.policies.data.ResourceGroup;
 
 /**
@@ -187,4 +188,53 @@ public interface ResourceGroups {
 
         CompletableFuture<Void> deleteResourceGroupAsync(String resourcegroup);
 
+        /**
+         * Set replicator message dispatch rate from a resource group.
+         *
+         * @param resourcegroup Resourcegroup name.
+         * @param cluster The remote cluster for which to set the replicator dispatch rate.
+         */
+        void setReplicatorDispatchRate(String resourcegroup, String cluster, DispatchRate dispatchRate)
+                throws PulsarAdminException;
+
+        /**
+         * Set replicator message dispatch rate from a resource group asynchronously.
+         *
+         * @param resourcegroup Resourcegroup name.
+         * @param cluster The remote cluster for which to set the replicator dispatch rate.
+         */
+        CompletableFuture<Void> setReplicatorDispatchRateAsync(String resourcegroup, String cluster,
+                                                               DispatchRate dispatchRate);
+
+        /**
+         * Remove replicator message dispatch rate from a resource group.
+         *
+         * @param resourcegroup Resourcegroup name.
+         * @param cluster The remote cluster for which to remove the replicator dispatch rate.
+         */
+        void removeReplicatorDispatchRate(String resourcegroup, String cluster) throws PulsarAdminException;
+
+        /**
+         * Remove replicator message dispatch rate from a resource group asynchronously.
+         *
+         * @param resourcegroup Resourcegroup name.
+         * @param cluster The remote cluster for which to remove the replicator dispatch rate.
+         */
+        CompletableFuture<Void> removeReplicatorDispatchRateAsync(String resourcegroup, String cluster);
+
+        /**
+         * Get replicator message dispatch rate for a resource group.
+         *
+         * @param resourcegroup Resourcegroup name.
+         * @param cluster The remote cluster for which to get the replicator dispatch rate.
+         */
+        DispatchRate getReplicatorDispatchRate(String resourcegroup, String cluster) throws PulsarAdminException;
+
+        /**
+         * Get replicator message dispatch rate for a resource group asynchronously.
+         *
+         * @param resourcegroup Resourcegroup name.
+         * @param cluster The remote cluster for which to get the replicator dispatch rate.
+         */
+        CompletableFuture<DispatchRate> getReplicatorDispatchRateAsync(String resourcegroup, String cluster);
 }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ResourceGroup.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ResourceGroup.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.common.policies.data;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.Data;
 
 @Data
@@ -29,4 +31,6 @@ public class ResourceGroup {
 
     private Long replicationDispatchRateInMsgs;
     private Long replicationDispatchRateInBytes;
+
+    private Map<String, DispatchRate> replicatorDispatchRate = new ConcurrentHashMap<>();
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ResourceGroupsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ResourceGroupsImpl.java
@@ -27,6 +27,7 @@ import javax.ws.rs.core.MediaType;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.admin.ResourceGroups;
 import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.policies.data.ResourceGroup;
 
 
@@ -116,5 +117,43 @@ public class ResourceGroupsImpl extends BaseResource implements ResourceGroups {
     public CompletableFuture<Void> deleteResourceGroupAsync(String name) {
         WebTarget path = adminResourceGroups.path(name);
         return asyncDeleteRequest(path);
+    }
+
+    @Override
+    public void setReplicatorDispatchRate(String resourcegroup, String cluster, DispatchRate dispatchRate)
+            throws PulsarAdminException {
+        sync(() -> setReplicatorDispatchRateAsync(resourcegroup, cluster, dispatchRate));
+    }
+
+    @Override
+    public CompletableFuture<Void> setReplicatorDispatchRateAsync(String resourcegroup, String cluster,
+                                                                  DispatchRate dispatchRate) {
+        WebTarget target =
+                adminResourceGroups.path(resourcegroup).path("replicatorDispatchRate").queryParam("cluster", cluster);
+        return asyncPostRequest(target, Entity.entity(dispatchRate, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public void removeReplicatorDispatchRate(String resourcegroup, String cluster) throws PulsarAdminException {
+        sync(() -> removeReplicatorDispatchRateAsync(resourcegroup, cluster));
+    }
+
+    @Override
+    public CompletableFuture<Void> removeReplicatorDispatchRateAsync(String resourcegroup, String cluster) {
+        WebTarget target =
+                adminResourceGroups.path(resourcegroup).path("replicatorDispatchRate").queryParam("cluster", cluster);
+        return asyncDeleteRequest(target);
+    }
+
+    @Override
+    public DispatchRate getReplicatorDispatchRate(String resourcegroup, String cluster) throws PulsarAdminException {
+        return sync(() -> getReplicatorDispatchRateAsync(resourcegroup, cluster));
+    }
+
+    @Override
+    public CompletableFuture<DispatchRate> getReplicatorDispatchRateAsync(String resourcegroup, String cluster) {
+        WebTarget target =
+                adminResourceGroups.path(resourcegroup).path("replicatorDispatchRate").queryParam("cluster", cluster);
+        return asyncGetRequest(target, DispatchRate.class);
     }
 }

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -55,6 +55,8 @@ import org.apache.pulsar.client.admin.Namespaces;
 import org.apache.pulsar.client.admin.NonPersistentTopics;
 import org.apache.pulsar.client.admin.ProxyStats;
 import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.admin.ResourceGroups;
 import org.apache.pulsar.client.admin.ResourceQuotas;
 import org.apache.pulsar.client.admin.Schemas;
 import org.apache.pulsar.client.admin.Tenants;
@@ -2197,6 +2199,28 @@ public class PulsarAdminToolTest {
 
         topicPolicies.run(split("remove-replicator-dispatch-rate tenant1/ns1/topic1 --cluster r1"));
         verify(mockTopicPolicies).removeReplicatorDispatchRate("persistent://tenant1/ns1/topic1", "r1");
+    }
+
+    @Test
+    public void testResourceGroupReplicatorDispatchRate() throws PulsarAdminException {
+        PulsarAdmin admin = Mockito.mock(PulsarAdmin.class);
+        ResourceGroups mockResourceGroups = mock(ResourceGroups.class);
+        when(admin.resourcegroups()).thenReturn(mockResourceGroups);
+
+        CmdResourceGroups cmdResourceGroups = new CmdResourceGroups(() -> admin);
+
+        cmdResourceGroups.run(split("set-replicator-dispatch-rate rg1 -md 10 -bd 11 --cluster r1"));
+        verify(mockResourceGroups).setReplicatorDispatchRate("rg1", "r1",
+                DispatchRate.builder()
+                        .dispatchThrottlingRateInMsg(10)
+                        .dispatchThrottlingRateInByte(11)
+                        .build());
+
+        cmdResourceGroups.run(split("get-replicator-dispatch-rate rg1 --cluster r1"));
+        verify(mockResourceGroups).getReplicatorDispatchRate("rg1", "r1");
+
+        cmdResourceGroups.run(split("remove-replicator-dispatch-rate rg1 --cluster r1"));
+        verify(mockResourceGroups).removeReplicatorDispatchRate("rg1", "r1");
     }
 
     public static class SchemaDemo {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdResourceGroups.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdResourceGroups.java
@@ -24,6 +24,7 @@ import com.beust.jcommander.Parameters;
 import java.util.function.Supplier;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.common.policies.data.DispatchRate;
 import org.apache.pulsar.common.policies.data.ResourceGroup;
 
 @Parameters(commandDescription = "Operations about ResourceGroups")
@@ -154,6 +155,68 @@ public class CmdResourceGroups extends CmdBase {
         }
     }
 
+    @Parameters(commandDescription = "Set replicator rate limiter for a resourcegroup")
+    private class SetReplicatorDispatchRate extends CliCommand {
+        @Parameter(description = "resourcegroup-name", required = true)
+        private java.util.List<String> params;
+
+        @Parameter(names = {"--msg-dispatch-rate",
+                "-md"}, description = "message-dispatch-rate "
+                + "(default -1 will be overwrite if not passed)", required = false)
+        private int msgDispatchRate = -1;
+
+        @Parameter(names = {"--byte-dispatch-rate",
+                "-bd"}, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)", required =
+                false)
+        private long byteDispatchRate = -1;
+
+        @Parameter(names = "--cluster", description = "The remote cluster for which set the dispatch rate", required
+                = true)
+        private String cluster;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String name = getOneArgument(params);
+            getAdmin().resourcegroups().setReplicatorDispatchRate(name, cluster,
+                    DispatchRate.builder()
+                            .dispatchThrottlingRateInMsg(msgDispatchRate)
+                            .dispatchThrottlingRateInByte(byteDispatchRate)
+                            .build());
+        }
+    }
+
+    @Parameters(commandDescription = "Get replicator rate limiter from a resourcegroup")
+    private class GetReplicatorDispatchRate extends CliCommand {
+        @Parameter(description = "resourcegroup-name", required = true)
+        private java.util.List<String> params;
+
+        @Parameter(names = "--cluster", description = "The remote cluster for which set the dispatch rate", required
+                = true)
+        private String cluster;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String name = getOneArgument(params);
+            print(getAdmin().resourcegroups().getReplicatorDispatchRate(name, cluster));
+        }
+    }
+
+    @Parameters(commandDescription = "Remove replicator rate limiter from a resourcegroup")
+    private class RemoveReplicatorDispatchRate extends CliCommand {
+        @Parameter(description = "resourcegroup-name", required = true)
+        private java.util.List<String> params;
+
+        @Parameter(names = "--cluster", description = "The remote cluster for which set the dispatch rate", required
+                = true)
+        private String cluster;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String name = getOneArgument(params);
+            getAdmin().resourcegroups().removeReplicatorDispatchRate(name, cluster);
+        }
+    }
+
 
     public CmdResourceGroups(Supplier<PulsarAdmin> admin) {
         super("resourcegroups", admin);
@@ -162,6 +225,10 @@ public class CmdResourceGroups extends CmdBase {
         jcommander.addCommand("create", new CmdResourceGroups.Create());
         jcommander.addCommand("update", new CmdResourceGroups.Update());
         jcommander.addCommand("delete", new CmdResourceGroups.Delete());
+
+        jcommander.addCommand("get-replicator-dispatch-rate", new GetReplicatorDispatchRate());
+        jcommander.addCommand("set-replicator-dispatch-rate", new SetReplicatorDispatchRate());
+        jcommander.addCommand("remove-replicator-dispatch-rate", new RemoveReplicatorDispatchRate());
     }
 
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdResourceGroups.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdResourceGroups.java
@@ -166,12 +166,12 @@ public class CmdResourceGroups extends CmdBase {
         private int msgDispatchRate = -1;
 
         @Parameter(names = {"--byte-dispatch-rate",
-                "-bd"}, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)", required =
-                false)
+                "-bd"}, description = "byte-dispatch-rate (default -1 will be overwrite if not passed)",
+                required = false)
         private long byteDispatchRate = -1;
 
-        @Parameter(names = "--cluster", description = "The remote cluster for which set the dispatch rate", required
-                = true)
+        @Parameter(names = "--cluster", description = "The remote cluster for which set the dispatch rate",
+                required = true)
         private String cluster;
 
         @Override
@@ -190,8 +190,8 @@ public class CmdResourceGroups extends CmdBase {
         @Parameter(description = "resourcegroup-name", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = "--cluster", description = "The remote cluster for which set the dispatch rate", required
-                = true)
+        @Parameter(names = "--cluster", description = "The remote cluster for which set the dispatch rate",
+                required = true)
         private String cluster;
 
         @Override
@@ -206,8 +206,8 @@ public class CmdResourceGroups extends CmdBase {
         @Parameter(description = "resourcegroup-name", required = true)
         private java.util.List<String> params;
 
-        @Parameter(names = "--cluster", description = "The remote cluster for which set the dispatch rate", required
-                = true)
+        @Parameter(names = "--cluster", description = "The remote cluster for which set the dispatch rate",
+                required = true)
         private String cluster;
 
         @Override


### PR DESCRIPTION
### Motivation

A feature that limits the replicator's rate based on the cluster name.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->