### PR TITLE
[improve][admin] Expose per-ledger props to getInternalStats

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -4542,6 +4542,13 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     // lookup metadata from the hashmap which contains completed async operations
                     info.metadata = ledgerMetadataFutures.get(li.getLedgerId()).getNow(null);
                 }
+                if (li.getPropertiesCount() > 0) {
+                    Map<String, String> properties = new HashMap<>(li.getPropertiesCount());
+                    for (MLDataFormats.KeyValue kv : li.getPropertiesList()) {
+                        properties.put(kv.getKey(), kv.getValue());
+                    }
+                    info.properties = properties;
+                }
                 stats.ledgers.add(info);
             });
             statFuture.complete(stats);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -83,6 +83,7 @@ import org.apache.bookkeeper.mledger.impl.ManagedCursorContainer.CursorInfo;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats;
 import org.apache.bookkeeper.mledger.util.ManagedLedgerImplUtils;
 import org.apache.bookkeeper.net.BookieId;
 import org.apache.commons.collections4.CollectionUtils;
@@ -2679,6 +2680,13 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                             info.entries = li.getEntries();
                             info.size = li.getSize();
                             info.offloaded = li.hasOffloadContext() && li.getOffloadContext().getComplete();
+                            if (li.getPropertiesCount() > 0) {
+                                Map<String, String> properties = new HashMap<>(li.getPropertiesCount());
+                                for (MLDataFormats.KeyValue kv : li.getPropertiesList()) {
+                                    properties.put(kv.getKey(), kv.getValue());
+                                }
+                                info.properties = properties;
+                            }
                             stats.ledgers.add(info);
                             if (includeLedgerMetadata) {
                                 futures.add(ml.getLedgerMetadata(li.getLedgerId()).handle((lMetadata, ex) -> {

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ManagedLedgerInternalStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ManagedLedgerInternalStats.java
@@ -77,6 +77,7 @@ public class ManagedLedgerInternalStats {
         public boolean offloaded;
         public String metadata;
         public boolean underReplicated;
+        public Map<String, String> properties;
     }
 
     /**


### PR DESCRIPTION
### Motivation

see https://github.com/apache/pulsar/pull/24336

### Modifications

<!-- Describe the modifications you've done. -->

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

