### PR TITLE
[improve][monitor] Add metrics to track the number of error_reponses was sent to clients

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
@@ -42,8 +42,8 @@ import org.apache.pulsar.common.util.netty.NettyChannelUtil;
 
 @Slf4j
 public class PulsarCommandSenderImpl implements PulsarCommandSender {
-    private static final Counter SEND_ERROR_COUNTER = Counter.build()
-            .name("pulsar_broker_send_error")
+    private static final Counter PROCESS_FAILURE_COUNTER = Counter.build()
+            .name("pulsar_broker_process_request_failures")
             .help("Number of send error responses sent by the broker")
             .labelNames("error")
             .register();
@@ -59,7 +59,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
     @Override
     public void sendPartitionMetadataResponse(ServerError error, String errorMsg, long requestId) {
         if (error != null) {
-            SEND_ERROR_COUNTER.labels(error.name()).inc();
+            PROCESS_FAILURE_COUNTER.labels(error.name()).inc();
         }
         BaseCommand command = Commands.newPartitionMetadataResponseCommand(error, errorMsg, requestId);
         safeIntercept(command, cnx);
@@ -86,7 +86,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
     @Override
     public void sendErrorResponse(long requestId, ServerError error, String message) {
         if (error != null) {
-            SEND_ERROR_COUNTER.labels(error.name()).inc();
+            PROCESS_FAILURE_COUNTER.labels(error.name()).inc();
         }
         BaseCommand command = Commands.newErrorCommand(requestId, error, message);
         safeIntercept(command, cnx);
@@ -126,7 +126,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
     @Override
     public void sendSendError(long producerId, long sequenceId, ServerError error, String errorMsg) {
         if (error != null) {
-            SEND_ERROR_COUNTER.labels(error.name()).inc();
+            PROCESS_FAILURE_COUNTER.labels(error.name()).inc();
         }
         BaseCommand command = Commands.newSendErrorCommand(producerId, sequenceId, error, errorMsg);
         safeIntercept(command, cnx);
@@ -155,7 +155,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
     @Override
     public void sendGetSchemaErrorResponse(long requestId, ServerError error, String errorMessage) {
         if (error != null) {
-            SEND_ERROR_COUNTER.labels(error.name()).inc();
+            PROCESS_FAILURE_COUNTER.labels(error.name()).inc();
         }
         BaseCommand command = Commands.newGetSchemaResponseErrorCommand(requestId, error, errorMessage);
         safeIntercept(command, cnx);
@@ -174,7 +174,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
     @Override
     public void sendGetOrCreateSchemaErrorResponse(long requestId, ServerError error, String errorMessage) {
         if (error != null) {
-            SEND_ERROR_COUNTER.labels(error.name()).inc();
+            PROCESS_FAILURE_COUNTER.labels(error.name()).inc();
         }
         BaseCommand command =
                 Commands.newGetOrCreateSchemaResponseErrorCommand(requestId, error, errorMessage);
@@ -206,7 +206,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
     @Override
     public void sendLookupResponse(ServerError error, String errorMsg, long requestId) {
         if (error != null) {
-            SEND_ERROR_COUNTER.labels(error.name()).inc();
+            PROCESS_FAILURE_COUNTER.labels(error.name()).inc();
         }
         BaseCommand command = Commands.newLookupErrorResponseCommand(error, errorMsg, requestId);
         safeIntercept(command, cnx);
@@ -329,7 +329,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
     @Override
     public void sendTcClientConnectResponse(long requestId, ServerError error, String message) {
         if (error != null) {
-            SEND_ERROR_COUNTER.labels(error.name()).inc();
+            PROCESS_FAILURE_COUNTER.labels(error.name()).inc();
         }
         BaseCommand command = Commands.newTcClientConnectResponse(requestId, error, message);
         safeIntercept(command, cnx);
@@ -357,7 +357,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
     @Override
     public void sendNewTxnErrorResponse(long requestId, long tcID, ServerError error, String message) {
         if (error != null) {
-            SEND_ERROR_COUNTER.labels(error.name()).inc();
+            PROCESS_FAILURE_COUNTER.labels(error.name()).inc();
         }
         BaseCommand command = Commands.newTxnResponse(requestId, tcID, error, message);
         safeIntercept(command, cnx);
@@ -380,7 +380,7 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
     @Override
     public void sendEndTxnErrorResponse(long requestId, TxnID txnID, ServerError error, String message) {
         if (error != null) {
-            SEND_ERROR_COUNTER.labels(error.name()).inc();
+            PROCESS_FAILURE_COUNTER.labels(error.name()).inc();
         }
         BaseCommand command = Commands.newEndTxnResponse(requestId, txnID.getLeastSigBits(),
                 txnID.getMostSigBits(), error, message);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarCommandSenderImpl.java
@@ -22,6 +22,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.prometheus.client.Counter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -41,6 +42,11 @@ import org.apache.pulsar.common.util.netty.NettyChannelUtil;
 
 @Slf4j
 public class PulsarCommandSenderImpl implements PulsarCommandSender {
+    private static final Counter SEND_ERROR_COUNTER = Counter.build()
+            .name("pulsar_broker_send_error")
+            .help("Number of send error responses sent by the broker")
+            .labelNames("error")
+            .register();
 
     private final BrokerInterceptor interceptor;
     private final ServerCnx cnx;
@@ -52,6 +58,9 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
 
     @Override
     public void sendPartitionMetadataResponse(ServerError error, String errorMsg, long requestId) {
+        if (error != null) {
+            SEND_ERROR_COUNTER.labels(error.name()).inc();
+        }
         BaseCommand command = Commands.newPartitionMetadataResponseCommand(error, errorMsg, requestId);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
@@ -76,6 +85,9 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
 
     @Override
     public void sendErrorResponse(long requestId, ServerError error, String message) {
+        if (error != null) {
+            SEND_ERROR_COUNTER.labels(error.name()).inc();
+        }
         BaseCommand command = Commands.newErrorCommand(requestId, error, message);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
@@ -113,6 +125,9 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
 
     @Override
     public void sendSendError(long producerId, long sequenceId, ServerError error, String errorMsg) {
+        if (error != null) {
+            SEND_ERROR_COUNTER.labels(error.name()).inc();
+        }
         BaseCommand command = Commands.newSendErrorCommand(producerId, sequenceId, error, errorMsg);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
@@ -139,6 +154,9 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
 
     @Override
     public void sendGetSchemaErrorResponse(long requestId, ServerError error, String errorMessage) {
+        if (error != null) {
+            SEND_ERROR_COUNTER.labels(error.name()).inc();
+        }
         BaseCommand command = Commands.newGetSchemaResponseErrorCommand(requestId, error, errorMessage);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
@@ -155,6 +173,9 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
 
     @Override
     public void sendGetOrCreateSchemaErrorResponse(long requestId, ServerError error, String errorMessage) {
+        if (error != null) {
+            SEND_ERROR_COUNTER.labels(error.name()).inc();
+        }
         BaseCommand command =
                 Commands.newGetOrCreateSchemaResponseErrorCommand(requestId, error, errorMessage);
         safeIntercept(command, cnx);
@@ -184,6 +205,9 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
 
     @Override
     public void sendLookupResponse(ServerError error, String errorMsg, long requestId) {
+        if (error != null) {
+            SEND_ERROR_COUNTER.labels(error.name()).inc();
+        }
         BaseCommand command = Commands.newLookupErrorResponseCommand(error, errorMsg, requestId);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
@@ -304,6 +328,9 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
 
     @Override
     public void sendTcClientConnectResponse(long requestId, ServerError error, String message) {
+        if (error != null) {
+            SEND_ERROR_COUNTER.labels(error.name()).inc();
+        }
         BaseCommand command = Commands.newTcClientConnectResponse(requestId, error, message);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
@@ -329,6 +356,9 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
 
     @Override
     public void sendNewTxnErrorResponse(long requestId, long tcID, ServerError error, String message) {
+        if (error != null) {
+            SEND_ERROR_COUNTER.labels(error.name()).inc();
+        }
         BaseCommand command = Commands.newTxnResponse(requestId, tcID, error, message);
         safeIntercept(command, cnx);
         ByteBuf outBuf = Commands.serializeWithSize(command);
@@ -349,6 +379,9 @@ public class PulsarCommandSenderImpl implements PulsarCommandSender {
 
     @Override
     public void sendEndTxnErrorResponse(long requestId, TxnID txnID, ServerError error, String message) {
+        if (error != null) {
+            SEND_ERROR_COUNTER.labels(error.name()).inc();
+        }
         BaseCommand command = Commands.newEndTxnResponse(requestId, txnID.getLeastSigBits(),
                 txnID.getMostSigBits(), error, message);
         safeIntercept(command, cnx);


### PR DESCRIPTION
### Motivation

Add metrics to track the number of error_reponses was sent to clients

### Modifications

1. Add `pulsar_broker_send_error` track the number of error_reponses was sent to clients.
2. Add `pulsar_broker_exceptions_caught` to track the number of exceptions which was not handled.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->
