### PR TITLE
[improve][broker] Migrate BK/DL dependencies to com.ascentstream

### DIFF
--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -163,7 +163,7 @@ function test_group_proxy() {
 
 function test_group_other() {
   mvn_test --clean --install \
-           -pl '!org.apache.pulsar:distribution,!org.apache.pulsar:pulsar-offloader-distribution,!org.apache.pulsar:pulsar-server-distribution,!org.apache.pulsar:pulsar-io-distribution,!org.apache.pulsar:pulsar-all-docker-image' \
+           -pl '!com.ascentstream.pulsar:distribution,!com.ascentstream.pulsar:pulsar-offloader-distribution,!com.ascentstream.pulsar:pulsar-server-distribution,!com.ascentstream.pulsar:pulsar-io-distribution,!com.ascentstream.pulsar:pulsar-all-docker-image' \
            -PskipTestsForUnitGroupOther -DdisableIoMainProfile=true -DdisableSqlMainProfile=true -DskipIntegrationTests \
            -Dexclude='**/ManagedLedgerTest.java,
                    **/OffloadersCacheTest.java

--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -185,7 +185,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper.stats</groupId>
+      <groupId>${bookkeeper.groupId}.stats</groupId>
       <artifactId>prometheus-metrics-provider</artifactId>
     </dependency>
 
@@ -275,7 +275,7 @@
 
     <!-- bookkeeper http server -->
     <dependency>
-      <groupId>org.apache.bookkeeper.http</groupId>
+      <groupId>${bookkeeper.groupId}.http</groupId>
       <artifactId>vertx-http-server</artifactId>
       <version>${bookkeeper.version}</version>
       <exclusions>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -408,34 +408,34 @@ The Apache Software License, Version 2.0
     - net.java.dev.jna-jna-jpms-5.12.1.jar
     - net.java.dev.jna-jna-platform-jpms-5.12.1.jar
  * BookKeeper
-    - org.apache.bookkeeper-bookkeeper-common-4.16.6.jar
-    - org.apache.bookkeeper-bookkeeper-common-allocator-4.16.6.jar
-    - org.apache.bookkeeper-bookkeeper-proto-4.16.6.jar
-    - org.apache.bookkeeper-bookkeeper-server-4.16.6.jar
-    - org.apache.bookkeeper-bookkeeper-tools-framework-4.16.6.jar
-    - org.apache.bookkeeper-circe-checksum-4.16.6.jar
-    - org.apache.bookkeeper-cpu-affinity-4.16.6.jar
-    - org.apache.bookkeeper-statelib-4.16.6.jar
-    - org.apache.bookkeeper-stream-storage-api-4.16.6.jar
-    - org.apache.bookkeeper-stream-storage-common-4.16.6.jar
-    - org.apache.bookkeeper-stream-storage-java-client-4.16.6.jar
-    - org.apache.bookkeeper-stream-storage-java-client-base-4.16.6.jar
-    - org.apache.bookkeeper-stream-storage-proto-4.16.6.jar
-    - org.apache.bookkeeper-stream-storage-server-4.16.6.jar
-    - org.apache.bookkeeper-stream-storage-service-api-4.16.6.jar
-    - org.apache.bookkeeper-stream-storage-service-impl-4.16.6.jar
-    - org.apache.bookkeeper.http-http-server-4.16.6.jar
-    - org.apache.bookkeeper.http-vertx-http-server-4.16.6.jar
-    - org.apache.bookkeeper.stats-bookkeeper-stats-api-4.16.6.jar
-    - org.apache.bookkeeper.stats-prometheus-metrics-provider-4.16.6.jar
-    - org.apache.distributedlog-distributedlog-common-4.16.6.jar
-    - org.apache.distributedlog-distributedlog-core-4.16.6-tests.jar
-    - org.apache.distributedlog-distributedlog-core-4.16.6.jar
-    - org.apache.distributedlog-distributedlog-protocol-4.16.6.jar
-    - org.apache.bookkeeper.stats-codahale-metrics-provider-4.16.6.jar
-    - org.apache.bookkeeper-bookkeeper-slogger-api-4.16.6.jar
-    - org.apache.bookkeeper-bookkeeper-slogger-slf4j-4.16.6.jar
-    - org.apache.bookkeeper-native-io-4.16.6.jar
+    - com.ascentstream.bookkeeper-bookkeeper-common-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-bookkeeper-common-allocator-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-bookkeeper-proto-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-bookkeeper-server-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-bookkeeper-tools-framework-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-circe-checksum-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-cpu-affinity-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-statelib-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-api-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-common-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-java-client-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-java-client-base-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-proto-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-server-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-service-api-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-service-impl-4.16.8.0.jar
+    - com.ascentstream.bookkeeper.http-http-server-4.16.8.0.jar
+    - com.ascentstream.bookkeeper.http-vertx-http-server-4.16.8.0.jar
+    - com.ascentstream.bookkeeper.stats-bookkeeper-stats-api-4.16.8.0.jar
+    - com.ascentstream.bookkeeper.stats-prometheus-metrics-provider-4.16.8.0.jar
+    - com.ascentstream.distributedlog-distributedlog-common-4.16.8.0.jar
+    - com.ascentstream.distributedlog-distributedlog-core-4.16.8.0-tests.jar
+    - com.ascentstream.distributedlog-distributedlog-core-4.16.8.0.jar
+    - com.ascentstream.distributedlog-distributedlog-protocol-4.16.8.0.jar
+    - com.ascentstream.bookkeeper.stats-codahale-metrics-provider-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-bookkeeper-slogger-api-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-bookkeeper-slogger-slf4j-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-native-io-4.16.8.0.jar
   * Apache HTTP Client
     - org.apache.httpcomponents-httpclient-4.5.13.jar
     - org.apache.httpcomponents-httpcore-4.4.15.jar

--- a/managed-ledger/pom.xml
+++ b/managed-ledger/pom.xml
@@ -34,17 +34,17 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-server</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper.stats</groupId>
+      <groupId>${bookkeeper.groupId}.stats</groupId>
       <artifactId>prometheus-metrics-provider</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper.stats</groupId>
+      <groupId>${bookkeeper.groupId}.stats</groupId>
       <artifactId>codahale-metrics-provider</artifactId>
       <version>${bookkeeper.version}</version>
       <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,10 @@ flexible messaging model and an intuitive client API.</description>
     <!-- apache commons -->
     <commons-compress.version>1.26.0</commons-compress.version>
 
-    <bookkeeper.version>4.16.6</bookkeeper.version>
+    <storage.groupId>com.ascentstream</storage.groupId>
+    <bookkeeper.groupId>${storage.groupId}.bookkeeper</bookkeeper.groupId>
+    <distributedlog.groupId>${storage.groupId}.distributedlog</distributedlog.groupId>
+    <bookkeeper.version>4.16.8.0</bookkeeper.version>
     <zookeeper.version>3.9.3</zookeeper.version>
     <commons-cli.version>1.5.0</commons-cli.version>
     <snappy.version>1.1.10.5</snappy.version> <!-- ZooKeeper server -->
@@ -457,7 +460,7 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>${bookkeeper.groupId}</groupId>
         <artifactId>bookkeeper-server</artifactId>
         <version>${bookkeeper.version}</version>
         <exclusions>
@@ -486,7 +489,7 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>${bookkeeper.groupId}</groupId>
         <artifactId>cpu-affinity</artifactId>
         <version>${bookkeeper.version}</version>
       </dependency>
@@ -515,13 +518,13 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>${bookkeeper.groupId}</groupId>
         <artifactId>bookkeeper-common-allocator</artifactId>
         <version>${bookkeeper.version}</version>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>${bookkeeper.groupId}</groupId>
         <artifactId>bookkeeper-tools-framework</artifactId>
         <version>${bookkeeper.version}</version>
       </dependency>
@@ -535,7 +538,7 @@ flexible messaging model and an intuitive client API.</description>
 
       <!-- exclude the grpc version from bookkeeper and use the one defined here -->
       <dependency>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>${bookkeeper.groupId}</groupId>
         <artifactId>stream-storage-java-client</artifactId>
         <version>${bookkeeper.version}</version>
         <exclusions>
@@ -572,7 +575,7 @@ flexible messaging model and an intuitive client API.</description>
 
       <!-- exclude the grpc version from bookkeeper and use the one defined here -->
       <dependency>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>${bookkeeper.groupId}</groupId>
         <artifactId>stream-storage-server</artifactId>
         <version>${bookkeeper.version}</version>
         <exclusions>
@@ -611,19 +614,19 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>${bookkeeper.groupId}</groupId>
         <artifactId>bookkeeper-common</artifactId>
         <version>${bookkeeper.version}</version>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper.stats</groupId>
+        <groupId>${bookkeeper.groupId}.stats</groupId>
         <artifactId>bookkeeper-stats-api</artifactId>
         <version>${bookkeeper.version}</version>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper.stats</groupId>
+        <groupId>${bookkeeper.groupId}.stats</groupId>
         <artifactId>datasketches-metrics-provider</artifactId>
         <version>${bookkeeper.version}</version>
         <exclusions>
@@ -635,7 +638,7 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper.stats</groupId>
+        <groupId>${bookkeeper.groupId}.stats</groupId>
         <artifactId>prometheus-metrics-provider</artifactId>
         <version>${bookkeeper.version}</version>
       </dependency>
@@ -1191,13 +1194,13 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.distributedlog</groupId>
+        <groupId>${distributedlog.groupId}</groupId>
         <artifactId>distributedlog-core</artifactId>
         <version>${bookkeeper.version}</version>
         <exclusions>
           <!-- exclude bookkeeper, reply on the bookkeeper version that pulsar uses -->
           <exclusion>
-            <groupId>org.apache.bookkeeper</groupId>
+            <groupId>${bookkeeper.groupId}</groupId>
             <artifactId>bookkeeper-server</artifactId>
           </exclusion>
         </exclusions>
@@ -1514,7 +1517,7 @@ flexible messaging model and an intuitive client API.</description>
 
     <dependency>
       <!-- We use MockedBookKeeper in many unit tests -->
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>${bookkeeper.version}</version>
       <scope>test</scope>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -94,7 +94,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>stream-storage-server</artifactId>
       <exclusions>
         <exclusion>
@@ -106,7 +106,7 @@
           <artifactId>*</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.bookkeeper.tests</groupId>
+          <groupId>${bookkeeper.groupId}.tests</groupId>
           <artifactId>stream-storage-tests-common</artifactId>
         </exclusion>
         <exclusion>
@@ -125,7 +125,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-tools-framework</artifactId>
     </dependency>
 

--- a/pulsar-client-admin-shaded/pom.xml
+++ b/pulsar-client-admin-shaded/pom.xml
@@ -126,7 +126,7 @@
                   <include>com.fasterxml.jackson.core</include>
                   <include>io.netty:*</include>
                   <include>com.ascentstream.pulsar:pulsar-common</include>
-                  <include>org.apache.bookkeeper:*</include>
+                  <include>${bookkeeper.groupId}:*</include>
                   <include>com.yahoo.datasketches:sketches-core</include>
                   <include>org.glassfish.jersey*:*</include>
                   <include>javax.ws.rs:*</include>

--- a/pulsar-client-all/pom.xml
+++ b/pulsar-client-all/pom.xml
@@ -166,7 +166,7 @@
                   <include>io.airlift:*</include>
 
                   <include>com.ascentstream.pulsar:pulsar-common</include>
-                  <include>org.apache.bookkeeper:*</include>
+                  <include>${bookkeeper.groupId}:*</include>
                   <include>com.yahoo.datasketches:sketches-core</include>
                   <include>org.glassfish.jersey*:*</include>
                   <include>javax.ws.rs:*</include>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -130,7 +130,7 @@
                 <includes>
                   <include>com.ascentstream.pulsar:pulsar-client-original</include>
                   <include>com.ascentstream.pulsar:pulsar-transaction-common</include>
-                  <include>org.apache.bookkeeper:*</include>
+                  <include>${bookkeeper.groupId}:*</include>
                   <include>org.apache.commons:commons-lang3</include>
                   <include>commons-codec:commons-codec</include>
                   <include>commons-collections:commons-collections</include>

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -95,7 +95,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-common-allocator</artifactId>
       <exclusions>
         <exclusion>
@@ -106,7 +106,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>cpu-affinity</artifactId>
     </dependency>
 
@@ -116,7 +116,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>circe-checksum</artifactId>
       <version>${bookkeeper.version}</version>
       <exclusions>

--- a/pulsar-functions/instance/pom.xml
+++ b/pulsar-functions/instance/pom.xml
@@ -102,7 +102,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>stream-storage-java-client</artifactId>
       <exclusions>
         <exclusion>
@@ -139,7 +139,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-common</artifactId>
       <exclusions>
         <exclusion>

--- a/pulsar-functions/localrun-shaded/pom.xml
+++ b/pulsar-functions/localrun-shaded/pom.xml
@@ -109,7 +109,7 @@
                             <artifactSet>
                                 <includes>
                                     <include>com.ascentstream.pulsar:*</include>
-                                    <include>org.apache.bookkeeper:*</include>
+                                    <include>${bookkeeper.groupId}:*</include>
                                     <include>commons-*:*</include>
                                     <include>org.apache.commons:*</include>
                                     <include>com.fasterxml.jackson.*:*</include>

--- a/pulsar-functions/worker/pom.xml
+++ b/pulsar-functions/worker/pom.xml
@@ -109,7 +109,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.distributedlog</groupId>
+      <groupId>${distributedlog.groupId}</groupId>
       <artifactId>distributedlog-core</artifactId>
       <exclusions>
         <exclusion>
@@ -120,7 +120,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-server</artifactId>
     </dependency>
 

--- a/pulsar-metadata/pom.xml
+++ b/pulsar-metadata/pom.xml
@@ -78,7 +78,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-server</artifactId>
     </dependency>
 

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/PulsarZooKeeperClient.java
@@ -240,9 +240,9 @@ public class PulsarZooKeeperClient extends ZooKeeper implements Watcher, AutoClo
 
             // Create a watcher manager
             StatsLogger watcherStatsLogger = statsLogger.scope("watcher");
-            ZooKeeperWatcherBase watcherManager =
-                    null == watchers ? new ZooKeeperWatcherBase(sessionTimeoutMs, watcherStatsLogger) :
-                            new ZooKeeperWatcherBase(sessionTimeoutMs, watchers, watcherStatsLogger);
+            ZooKeeperWatcherBase watcherManager = null == watchers
+                    ? new ZooKeeperWatcherBase(sessionTimeoutMs, allowReadOnlyMode, watcherStatsLogger)
+                    : new ZooKeeperWatcherBase(sessionTimeoutMs, allowReadOnlyMode, watchers, watcherStatsLogger);
             PulsarZooKeeperClient client = new PulsarZooKeeperClient(
                     connectString,
                     sessionTimeoutMs,

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClientTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/bookkeeper/PulsarRegistrationClientTest.java
@@ -365,7 +365,7 @@ public class PulsarRegistrationClientTest extends BaseMetadataStoreTest {
         final String zksConnectionString = zks.getConnectionString();
         final String ledgersRoot = "/test/ledgers-" + UUID.randomUUID();
         // prepare registration manager
-        ZooKeeper zk = new ZooKeeper(zksConnectionString, 5000, new ZooKeeperWatcherBase(1000));
+        ZooKeeper zk = new ZooKeeper(zksConnectionString, 5000, new ZooKeeperWatcherBase(1000, false));
         final ServerConfiguration serverConfiguration = new ServerConfiguration();
         serverConfiguration.setZkLedgersRootPath(ledgersRoot);
         final FaultInjectableZKRegistrationManager rm = new FaultInjectableZKRegistrationManager(serverConfiguration, zk);

--- a/pulsar-package-management/bookkeeper-storage/pom.xml
+++ b/pulsar-package-management/bookkeeper-storage/pom.xml
@@ -40,7 +40,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.distributedlog</groupId>
+            <groupId>${distributedlog.groupId}</groupId>
             <artifactId>distributedlog-core</artifactId>
             <exclusions>
                 <exclusion>

--- a/testmocks/pom.xml
+++ b/testmocks/pom.xml
@@ -54,7 +54,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-server</artifactId>
     </dependency>
 


### PR DESCRIPTION
### Motivation

The broker currently depends on upstream BookKeeper and DistributedLog artifacts under the `org.apache.*` namespace.

To align with the internal storage distribution and simplify dependency/version management, this change migrates those dependencies to the `com.ascentstream.*` namespace.

This also improves consistency across BookKeeper and DistributedLog modules and prepares for unified storage dependency management.

### Modifications

- Migrated BookKeeper dependencies from `org.apache.*` to `com.ascentstream.*`
- Migrated DistributedLog dependencies to the `com.ascentstream.*` namespace
- Unified storage-related Maven version properties
- Updated related dependency declarations and build configuration