### PR TITLE
[improve][broker] Migrate BK/DL dependencies to com.ascentstream

### DIFF
--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -190,7 +190,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper.stats</groupId>
+      <groupId>${bookkeeper.groupId}.stats</groupId>
       <artifactId>prometheus-metrics-provider</artifactId>
     </dependency>
 
@@ -284,7 +284,7 @@
 
     <!-- bookkeeper http server -->
     <dependency>
-      <groupId>org.apache.bookkeeper.http</groupId>
+      <groupId>${bookkeeper.groupId}.http</groupId>
       <artifactId>vertx-http-server</artifactId>
       <version>${bookkeeper.version}</version>
       <exclusions>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -345,34 +345,34 @@ The Apache Software License, Version 2.0
     - net.java.dev.jna-jna-jpms-5.12.1.jar
     - net.java.dev.jna-jna-platform-jpms-5.12.1.jar
  * BookKeeper
-    - org.apache.bookkeeper-bookkeeper-common-4.16.7.jar
-    - org.apache.bookkeeper-bookkeeper-common-allocator-4.16.7.jar
-    - org.apache.bookkeeper-bookkeeper-proto-4.16.7.jar
-    - org.apache.bookkeeper-bookkeeper-server-4.16.7.jar
-    - org.apache.bookkeeper-bookkeeper-tools-framework-4.16.7.jar
-    - org.apache.bookkeeper-circe-checksum-4.16.7.jar
-    - org.apache.bookkeeper-cpu-affinity-4.16.7.jar
-    - org.apache.bookkeeper-statelib-4.16.7.jar
-    - org.apache.bookkeeper-stream-storage-api-4.16.7.jar
-    - org.apache.bookkeeper-stream-storage-common-4.16.7.jar
-    - org.apache.bookkeeper-stream-storage-java-client-4.16.7.jar
-    - org.apache.bookkeeper-stream-storage-java-client-base-4.16.7.jar
-    - org.apache.bookkeeper-stream-storage-proto-4.16.7.jar
-    - org.apache.bookkeeper-stream-storage-server-4.16.7.jar
-    - org.apache.bookkeeper-stream-storage-service-api-4.16.7.jar
-    - org.apache.bookkeeper-stream-storage-service-impl-4.16.7.jar
-    - org.apache.bookkeeper.http-http-server-4.16.7.jar
-    - org.apache.bookkeeper.http-vertx-http-server-4.16.7.jar
-    - org.apache.bookkeeper.stats-bookkeeper-stats-api-4.16.7.jar
-    - org.apache.bookkeeper.stats-prometheus-metrics-provider-4.16.7.jar
-    - org.apache.distributedlog-distributedlog-common-4.16.7.jar
-    - org.apache.distributedlog-distributedlog-core-4.16.7-tests.jar
-    - org.apache.distributedlog-distributedlog-core-4.16.7.jar
-    - org.apache.distributedlog-distributedlog-protocol-4.16.7.jar
-    - org.apache.bookkeeper.stats-codahale-metrics-provider-4.16.7.jar
-    - org.apache.bookkeeper-bookkeeper-slogger-api-4.16.7.jar
-    - org.apache.bookkeeper-bookkeeper-slogger-slf4j-4.16.7.jar
-    - org.apache.bookkeeper-native-io-4.16.7.jar
+    - com.ascentstream.bookkeeper-bookkeeper-common-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-bookkeeper-common-allocator-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-bookkeeper-proto-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-bookkeeper-server-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-bookkeeper-tools-framework-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-circe-checksum-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-cpu-affinity-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-statelib-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-api-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-common-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-java-client-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-java-client-base-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-proto-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-server-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-service-api-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-service-impl-4.16.8.0.jar
+    - com.ascentstream.bookkeeper.http-http-server-4.16.8.0.jar
+    - com.ascentstream.bookkeeper.http-vertx-http-server-4.16.8.0.jar
+    - com.ascentstream.bookkeeper.stats-bookkeeper-stats-api-4.16.8.0.jar
+    - com.ascentstream.bookkeeper.stats-prometheus-metrics-provider-4.16.8.0.jar
+    - com.ascentstream.distributedlog-distributedlog-common-4.16.8.0.jar
+    - com.ascentstream.distributedlog-distributedlog-core-4.16.8.0-tests.jar
+    - com.ascentstream.distributedlog-distributedlog-core-4.16.8.0.jar
+    - com.ascentstream.distributedlog-distributedlog-protocol-4.16.8.0.jar
+    - com.ascentstream.bookkeeper.stats-codahale-metrics-provider-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-bookkeeper-slogger-api-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-bookkeeper-slogger-slf4j-4.16.8.0.jar
+    - com.ascentstream.bookkeeper-native-io-4.16.8.0.jar
   * Apache HTTP Client
     - org.apache.httpcomponents-httpclient-4.5.13.jar
     - org.apache.httpcomponents-httpcore-4.4.15.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -390,9 +390,9 @@ The Apache Software License, Version 2.0
     - log4j-web-2.25.4.jar
 
  * BookKeeper
-    - bookkeeper-common-allocator-4.16.7.jar
-    - cpu-affinity-4.16.7.jar
-    - circe-checksum-4.16.7.jar
+    - bookkeeper-common-allocator-4.16.8.0.jar
+    - cpu-affinity-4.16.8.0.jar
+    - circe-checksum-4.16.8.0.jar
   * AirCompressor
      - aircompressor-2.0.3.jar
  * AsyncHttpClient

--- a/managed-ledger/pom.xml
+++ b/managed-ledger/pom.xml
@@ -34,17 +34,17 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-server</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper.stats</groupId>
+      <groupId>${bookkeeper.groupId}.stats</groupId>
       <artifactId>prometheus-metrics-provider</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper.stats</groupId>
+      <groupId>${bookkeeper.groupId}.stats</groupId>
       <artifactId>codahale-metrics-provider</artifactId>
       <version>${bookkeeper.version}</version>
       <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,10 @@ flexible messaging model and an intuitive client API.</description>
     <!-- apache commons -->
     <commons-compress.version>1.26.0</commons-compress.version>
 
-    <bookkeeper.version>4.16.7</bookkeeper.version>
+    <storage.groupId>com.ascentstream</storage.groupId>
+    <bookkeeper.groupId>${storage.groupId}.bookkeeper</bookkeeper.groupId>
+    <distributedlog.groupId>${storage.groupId}.distributedlog</distributedlog.groupId>
+    <bookkeeper.version>4.16.8.0</bookkeeper.version>
     <zookeeper.version>3.9.5</zookeeper.version>
     <commons-cli.version>1.5.0</commons-cli.version>
     <commons-text.version>1.10.0</commons-text.version>
@@ -474,7 +477,7 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>${bookkeeper.groupId}</groupId>
         <artifactId>bookkeeper-server</artifactId>
         <version>${bookkeeper.version}</version>
         <exclusions>
@@ -503,7 +506,7 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>${bookkeeper.groupId}</groupId>
         <artifactId>cpu-affinity</artifactId>
         <version>${bookkeeper.version}</version>
       </dependency>
@@ -537,13 +540,13 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>${bookkeeper.groupId}</groupId>
         <artifactId>bookkeeper-common-allocator</artifactId>
         <version>${bookkeeper.version}</version>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>${bookkeeper.groupId}</groupId>
         <artifactId>bookkeeper-tools-framework</artifactId>
         <version>${bookkeeper.version}</version>
       </dependency>
@@ -557,7 +560,7 @@ flexible messaging model and an intuitive client API.</description>
 
       <!-- exclude the grpc version from bookkeeper and use the one defined here -->
       <dependency>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>${bookkeeper.groupId}</groupId>
         <artifactId>stream-storage-java-client</artifactId>
         <version>${bookkeeper.version}</version>
         <exclusions>
@@ -594,7 +597,7 @@ flexible messaging model and an intuitive client API.</description>
 
       <!-- exclude the grpc version from bookkeeper and use the one defined here -->
       <dependency>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>${bookkeeper.groupId}</groupId>
         <artifactId>stream-storage-server</artifactId>
         <version>${bookkeeper.version}</version>
         <exclusions>
@@ -633,19 +636,19 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>${bookkeeper.groupId}</groupId>
         <artifactId>bookkeeper-common</artifactId>
         <version>${bookkeeper.version}</version>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper.stats</groupId>
+        <groupId>${bookkeeper.groupId}.stats</groupId>
         <artifactId>bookkeeper-stats-api</artifactId>
         <version>${bookkeeper.version}</version>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper.stats</groupId>
+        <groupId>${bookkeeper.groupId}.stats</groupId>
         <artifactId>datasketches-metrics-provider</artifactId>
         <version>${bookkeeper.version}</version>
         <exclusions>
@@ -657,7 +660,7 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper.stats</groupId>
+        <groupId>${bookkeeper.groupId}.stats</groupId>
         <artifactId>prometheus-metrics-provider</artifactId>
         <version>${bookkeeper.version}</version>
       </dependency>
@@ -1308,13 +1311,13 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.distributedlog</groupId>
+        <groupId>${distributedlog.groupId}</groupId>
         <artifactId>distributedlog-core</artifactId>
         <version>${bookkeeper.version}</version>
         <exclusions>
           <!-- exclude bookkeeper, reply on the bookkeeper version that pulsar uses -->
           <exclusion>
-            <groupId>org.apache.bookkeeper</groupId>
+            <groupId>${bookkeeper.groupId}</groupId>
             <artifactId>bookkeeper-server</artifactId>
           </exclusion>
         </exclusions>
@@ -1631,7 +1634,7 @@ flexible messaging model and an intuitive client API.</description>
 
     <dependency>
       <!-- We use MockedBookKeeper in many unit tests -->
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>${bookkeeper.version}</version>
       <scope>test</scope>
@@ -1661,7 +1664,7 @@ flexible messaging model and an intuitive client API.</description>
     </dependency>
     <dependency>
       <!-- We use TestStatsProvider in many unit tests -->
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-common</artifactId>
       <version>${bookkeeper.version}</version>
       <scope>test</scope>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -94,7 +94,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>stream-storage-server</artifactId>
       <exclusions>
         <exclusion>
@@ -106,7 +106,7 @@
           <artifactId>*</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.bookkeeper.tests</groupId>
+          <groupId>${bookkeeper.groupId}.tests</groupId>
           <artifactId>stream-storage-tests-common</artifactId>
         </exclusion>
         <exclusion>
@@ -121,7 +121,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-tools-framework</artifactId>
     </dependency>
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -2575,6 +2575,7 @@ public class ServerCnxTest {
         setChannelConnected();
 
         var ctx = mock(ChannelHandlerContext.class);
+        when(ctx.channel()).thenReturn(channel);
         var writeFuture = mock(ChannelFuture.class);
         var writeFailure = new RuntimeException("close consumer write failed");
         when(ctx.writeAndFlush(any())).thenReturn(writeFuture);

--- a/pulsar-client-admin-shaded/pom.xml
+++ b/pulsar-client-admin-shaded/pom.xml
@@ -132,7 +132,7 @@
                   <include>javax.ws.rs:*</include>
                   <include>javax.xml.bind:jaxb-api</include>
                   <include>net.jcip:jcip-annotations</include>
-                  <include>org.apache.bookkeeper:*</include>
+                  <include>${bookkeeper.groupId}:*</include>
                   <include>org.apache.commons:commons-compress</include>
                   <include>org.apache.commons:commons-lang3</include>
                   <include>org.apache.pulsar:pulsar-client-admin-original</include>

--- a/pulsar-client-all/pom.xml
+++ b/pulsar-client-all/pom.xml
@@ -181,7 +181,7 @@
                   <include>javax.xml.bind:jaxb-api</include>
                   <include>net.jcip:jcip-annotations</include>
                   <include>org.apache.avro:*</include>
-                  <include>org.apache.bookkeeper:*</include>
+                  <include>${bookkeeper.groupId}:*</include>
                   <include>org.apache.commons:commons-compress</include>
                   <include>org.apache.commons:commons-lang3</include>
                   <include>org.apache.pulsar:pulsar-client-admin-original</include>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -149,7 +149,7 @@
                   <include>javax.ws.rs:*</include>
                   <include>net.jcip:jcip-annotations</include>
                   <include>org.apache.avro:*</include>
-                  <include>org.apache.bookkeeper:*</include>
+                  <include>${bookkeeper.groupId}:*</include>
                   <include>org.apache.commons:commons-compress</include>
                   <include>org.apache.commons:commons-lang3</include>
                   <!-- Issue #6834, Since Netty ByteBuf shaded, we need also shade this module -->

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -110,7 +110,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-common-allocator</artifactId>
       <exclusions>
         <exclusion>
@@ -121,7 +121,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>cpu-affinity</artifactId>
     </dependency>
 
@@ -131,7 +131,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>circe-checksum</artifactId>
       <version>${bookkeeper.version}</version>
       <exclusions>

--- a/pulsar-functions/instance/pom.xml
+++ b/pulsar-functions/instance/pom.xml
@@ -96,7 +96,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>stream-storage-java-client</artifactId>
       <exclusions>
         <exclusion>
@@ -133,7 +133,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-common</artifactId>
       <exclusions>
         <exclusion>

--- a/pulsar-functions/localrun-shaded/pom.xml
+++ b/pulsar-functions/localrun-shaded/pom.xml
@@ -109,7 +109,7 @@
                             <artifactSet>
                                 <includes>
                                     <include>org.apache.pulsar:*</include>
-                                    <include>org.apache.bookkeeper:*</include>
+                                    <include>${bookkeeper.groupId}:*</include>
                                     <include>commons-*:*</include>
                                     <include>org.apache.commons:*</include>
                                     <include>com.fasterxml.jackson.*:*</include>

--- a/pulsar-functions/worker/pom.xml
+++ b/pulsar-functions/worker/pom.xml
@@ -109,7 +109,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.distributedlog</groupId>
+      <groupId>${distributedlog.groupId}</groupId>
       <artifactId>distributedlog-core</artifactId>
       <exclusions>
         <exclusion>
@@ -120,7 +120,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-server</artifactId>
     </dependency>
 

--- a/pulsar-metadata/pom.xml
+++ b/pulsar-metadata/pom.xml
@@ -104,7 +104,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-server</artifactId>
     </dependency>
 

--- a/pulsar-package-management/bookkeeper-storage/pom.xml
+++ b/pulsar-package-management/bookkeeper-storage/pom.xml
@@ -40,7 +40,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.distributedlog</groupId>
+            <groupId>${distributedlog.groupId}</groupId>
             <artifactId>distributedlog-core</artifactId>
             <exclusions>
                 <exclusion>

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -231,33 +231,33 @@ The Apache Software License, Version 2.0
     - commons-compress-1.26.0.jar
     - commons-lang3-3.18.0.jar
  * Netty
-    - netty-buffer-4.1.132.Final.jar
-    - netty-codec-4.1.132.Final.jar
-    - netty-codec-dns-4.1.132.Final.jar
-    - netty-codec-http-4.1.132.Final.jar
-    - netty-codec-haproxy-4.1.132.Final.jar
-    - netty-codec-socks-4.1.132.Final.jar
-    - netty-handler-proxy-4.1.132.Final.jar
-    - netty-common-4.1.132.Final.jar
-    - netty-handler-4.1.132.Final.jar
+    - netty-buffer-4.1.133.Final.jar
+    - netty-codec-4.1.133.Final.jar
+    - netty-codec-dns-4.1.133.Final.jar
+    - netty-codec-http-4.1.133.Final.jar
+    - netty-codec-haproxy-4.1.133.Final.jar
+    - netty-codec-socks-4.1.133.Final.jar
+    - netty-handler-proxy-4.1.133.Final.jar
+    - netty-common-4.1.133.Final.jar
+    - netty-handler-4.1.133.Final.jar
     - netty-reactive-streams-2.0.6.jar
-    - netty-resolver-4.1.132.Final.jar
-    - netty-resolver-dns-4.1.132.Final.jar
-    - netty-resolver-dns-classes-macos-4.1.132.Final.jar
-    - netty-resolver-dns-native-macos-4.1.132.Final-osx-aarch_64.jar
-    - netty-resolver-dns-native-macos-4.1.132.Final-osx-x86_64.jar
-    - netty-tcnative-boringssl-static-2.0.75.Final.jar
-    - netty-tcnative-boringssl-static-2.0.75.Final-linux-aarch_64.jar
-    - netty-tcnative-boringssl-static-2.0.75.Final-linux-x86_64.jar
-    - netty-tcnative-boringssl-static-2.0.75.Final-osx-aarch_64.jar
-    - netty-tcnative-boringssl-static-2.0.75.Final-osx-x86_64.jar
-    - netty-tcnative-boringssl-static-2.0.75.Final-windows-x86_64.jar
-    - netty-tcnative-classes-2.0.75.Final.jar
-    - netty-transport-4.1.132.Final.jar
-    - netty-transport-classes-epoll-4.1.132.Final.jar
-    - netty-transport-native-epoll-4.1.132.Final-linux-aarch_64.jar
-    - netty-transport-native-epoll-4.1.132.Final-linux-x86_64.jar
-    - netty-transport-native-unix-common-4.1.132.Final.jar
+    - netty-resolver-4.1.133.Final.jar
+    - netty-resolver-dns-4.1.133.Final.jar
+    - netty-resolver-dns-classes-macos-4.1.133.Final.jar
+    - netty-resolver-dns-native-macos-4.1.133.Final-osx-aarch_64.jar
+    - netty-resolver-dns-native-macos-4.1.133.Final-osx-x86_64.jar
+    - netty-tcnative-boringssl-static-2.0.77.Final.jar
+    - netty-tcnative-boringssl-static-2.0.77.Final-linux-aarch_64.jar
+    - netty-tcnative-boringssl-static-2.0.77.Final-linux-x86_64.jar
+    - netty-tcnative-boringssl-static-2.0.77.Final-osx-aarch_64.jar
+    - netty-tcnative-boringssl-static-2.0.77.Final-osx-x86_64.jar
+    - netty-tcnative-boringssl-static-2.0.77.Final-windows-x86_64.jar
+    - netty-tcnative-classes-2.0.77.Final.jar
+    - netty-transport-4.1.133.Final.jar
+    - netty-transport-classes-epoll-4.1.133.Final.jar
+    - netty-transport-native-epoll-4.1.133.Final-linux-aarch_64.jar
+    - netty-transport-native-epoll-4.1.133.Final-linux-x86_64.jar
+    - netty-transport-native-unix-common-4.1.133.Final.jar
     - netty-incubator-transport-classes-io_uring-0.0.26.Final.jar
     - netty-incubator-transport-native-io_uring-0.0.26.Final-linux-x86_64.jar
     - netty-incubator-transport-native-io_uring-0.0.26.Final-linux-aarch_64.jar

--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -423,21 +423,21 @@ The Apache Software License, Version 2.0
     - async-http-client-2.14.5.jar
     - async-http-client-netty-utils-2.14.5.jar
   * Apache Bookkeeper
-    - bookkeeper-common-4.16.7.jar
-    - bookkeeper-common-allocator-4.16.7.jar
-    - bookkeeper-proto-4.16.7.jar
-    - bookkeeper-server-4.16.7.jar
-    - bookkeeper-stats-api-4.16.7.jar
-    - bookkeeper-tools-framework-4.16.7.jar
-    - circe-checksum-4.16.7.jar
-    - codahale-metrics-provider-4.16.7.jar
-    - cpu-affinity-4.16.7.jar
-    - http-server-4.16.7.jar
-    - prometheus-metrics-provider-4.16.7.jar
-    - codahale-metrics-provider-4.16.7.jar
-    - bookkeeper-slogger-api-4.16.7.jar
-    - bookkeeper-slogger-slf4j-4.16.7.jar
-    - native-io-4.16.7.jar
+    - bookkeeper-common-4.16.8.0.jar
+    - bookkeeper-common-allocator-4.16.8.0.jar
+    - bookkeeper-proto-4.16.8.0.jar
+    - bookkeeper-server-4.16.8.0.jar
+    - bookkeeper-stats-api-4.16.8.0.jar
+    - bookkeeper-tools-framework-4.16.8.0.jar
+    - circe-checksum-4.16.8.0.jar
+    - codahale-metrics-provider-4.16.8.0.jar
+    - cpu-affinity-4.16.8.0.jar
+    - http-server-4.16.8.0.jar
+    - prometheus-metrics-provider-4.16.8.0.jar
+    - codahale-metrics-provider-4.16.8.0.jar
+    - bookkeeper-slogger-api-4.16.8.0.jar
+    - bookkeeper-slogger-slf4j-4.16.8.0.jar
+    - native-io-4.16.8.0.jar
   * Apache Commons
     - commons-cli-1.5.0.jar
     - commons-codec-1.15.jar

--- a/testmocks/pom.xml
+++ b/testmocks/pom.xml
@@ -54,7 +54,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-server</artifactId>
     </dependency>
 


### PR DESCRIPTION
### Motivation

The broker currently depends on upstream BookKeeper and DistributedLog artifacts under the `org.apache.*` namespace.

To align with the internal storage distribution and simplify dependency/version management, this change migrates those dependencies to the `com.ascentstream.*` namespace.

This also improves consistency across BookKeeper and DistributedLog modules and prepares for unified storage dependency management.

### Modifications

- Migrated BookKeeper dependencies from `org.apache.*` to `com.ascentstream.*`
- Migrated DistributedLog dependencies to the `com.ascentstream.*` namespace
- Unified storage-related Maven version properties
- Updated related dependency declarations and build configuration