### PR TITLE
[improve][broker] Migrate BK/DL dependencies to com.ascentstream

### DIFF
--- a/build/run_unit_group.sh
+++ b/build/run_unit_group.sh
@@ -175,7 +175,7 @@ function test_group_proxy() {
 
 function test_group_other() {
   mvn_test --clean --install \
-           -pl '!org.apache.pulsar:distribution,!org.apache.pulsar:pulsar-offloader-distribution,!org.apache.pulsar:pulsar-server-distribution,!org.apache.pulsar:pulsar-io-distribution,!org.apache.pulsar:pulsar-docker-image,!org.apache.pulsar:pulsar-all-docker-image' \
+           -pl '!com.ascentstream.pulsar:distribution,!com.ascentstream.pulsar:pulsar-offloader-distribution,!com.ascentstream.pulsar:pulsar-server-distribution,!com.ascentstream.pulsar:pulsar-io-distribution,!com.ascentstream.pulsar:pulsar-docker-image,!com.ascentstream.pulsar:pulsar-all-docker-image' \
            -PskipTestsForUnitGroupOther -DdisableIoMainProfile=true -DskipIntegrationTests \
            -Dexclude='**/ManagedLedgerTest.java,
                    **/OffloadersCacheTest.java,

--- a/distribution/server/pom.xml
+++ b/distribution/server/pom.xml
@@ -200,7 +200,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper.stats</groupId>
+      <groupId>${bookkeeper.groupId}.stats</groupId>
       <artifactId>prometheus-metrics-provider</artifactId>
     </dependency>
 
@@ -294,7 +294,7 @@
 
     <!-- bookkeeper http server -->
     <dependency>
-      <groupId>org.apache.bookkeeper.http</groupId>
+      <groupId>${bookkeeper.groupId}.http</groupId>
       <artifactId>vertx-http-server</artifactId>
       <version>${bookkeeper.version}</version>
       <exclusions>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -357,34 +357,34 @@ The Apache Software License, Version 2.0
     - net.java.dev.jna-jna-jpms-5.12.1.jar
     - net.java.dev.jna-jna-platform-jpms-5.12.1.jar
  * BookKeeper
-    - org.apache.bookkeeper-bookkeeper-common-4.17.3.jar
-    - org.apache.bookkeeper-bookkeeper-common-allocator-4.17.3.jar
-    - org.apache.bookkeeper-bookkeeper-proto-4.17.3.jar
-    - org.apache.bookkeeper-bookkeeper-server-4.17.3.jar
-    - org.apache.bookkeeper-bookkeeper-tools-framework-4.17.3.jar
-    - org.apache.bookkeeper-circe-checksum-4.17.3.jar
-    - org.apache.bookkeeper-cpu-affinity-4.17.3.jar
-    - org.apache.bookkeeper-statelib-4.17.3.jar
-    - org.apache.bookkeeper-stream-storage-api-4.17.3.jar
-    - org.apache.bookkeeper-stream-storage-common-4.17.3.jar
-    - org.apache.bookkeeper-stream-storage-java-client-4.17.3.jar
-    - org.apache.bookkeeper-stream-storage-java-client-base-4.17.3.jar
-    - org.apache.bookkeeper-stream-storage-proto-4.17.3.jar
-    - org.apache.bookkeeper-stream-storage-server-4.17.3.jar
-    - org.apache.bookkeeper-stream-storage-service-api-4.17.3.jar
-    - org.apache.bookkeeper-stream-storage-service-impl-4.17.3.jar
-    - org.apache.bookkeeper.http-http-server-4.17.3.jar
-    - org.apache.bookkeeper.http-vertx-http-server-4.17.3.jar
-    - org.apache.bookkeeper.stats-bookkeeper-stats-api-4.17.3.jar
-    - org.apache.bookkeeper.stats-prometheus-metrics-provider-4.17.3.jar
-    - org.apache.distributedlog-distributedlog-common-4.17.3.jar
-    - org.apache.distributedlog-distributedlog-core-4.17.3-tests.jar
-    - org.apache.distributedlog-distributedlog-core-4.17.3.jar
-    - org.apache.distributedlog-distributedlog-protocol-4.17.3.jar
-    - org.apache.bookkeeper.stats-codahale-metrics-provider-4.17.3.jar
-    - org.apache.bookkeeper-bookkeeper-slogger-api-4.17.3.jar
-    - org.apache.bookkeeper-bookkeeper-slogger-slf4j-4.17.3.jar
-    - org.apache.bookkeeper-native-io-4.17.3.jar
+    - com.ascentstream.bookkeeper-bookkeeper-common-4.17.4.0.jar
+    - com.ascentstream.bookkeeper-bookkeeper-common-allocator-4.17.4.0.jar
+    - com.ascentstream.bookkeeper-bookkeeper-proto-4.17.4.0.jar
+    - com.ascentstream.bookkeeper-bookkeeper-server-4.17.4.0.jar
+    - com.ascentstream.bookkeeper-bookkeeper-tools-framework-4.17.4.0.jar
+    - com.ascentstream.bookkeeper-circe-checksum-4.17.4.0.jar
+    - com.ascentstream.bookkeeper-cpu-affinity-4.17.4.0.jar
+    - com.ascentstream.bookkeeper-statelib-4.17.4.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-api-4.17.4.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-common-4.17.4.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-java-client-4.17.4.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-java-client-base-4.17.4.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-proto-4.17.4.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-server-4.17.4.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-service-api-4.17.4.0.jar
+    - com.ascentstream.bookkeeper-stream-storage-service-impl-4.17.4.0.jar
+    - com.ascentstream.bookkeeper.http-http-server-4.17.4.0.jar
+    - com.ascentstream.bookkeeper.http-vertx-http-server-4.17.4.0.jar
+    - com.ascentstream.bookkeeper.stats-bookkeeper-stats-api-4.17.4.0.jar
+    - com.ascentstream.bookkeeper.stats-prometheus-metrics-provider-4.17.4.0.jar
+    - com.ascentstream.distributedlog-distributedlog-common-4.17.4.0.jar
+    - com.ascentstream.distributedlog-distributedlog-core-4.17.4.0-tests.jar
+    - com.ascentstream.distributedlog-distributedlog-core-4.17.4.0.jar
+    - com.ascentstream.distributedlog-distributedlog-protocol-4.17.4.0.jar
+    - com.ascentstream.bookkeeper.stats-codahale-metrics-provider-4.17.4.0.jar
+    - com.ascentstream.bookkeeper-bookkeeper-slogger-api-4.17.4.0.jar
+    - com.ascentstream.bookkeeper-bookkeeper-slogger-slf4j-4.17.4.0.jar
+    - com.ascentstream.bookkeeper-native-io-4.17.4.0.jar
     - at.yawk.lz4-lz4-java-1.10.3.jar
   * Apache HTTP Client
     - org.apache.httpcomponents-httpclient-4.5.13.jar

--- a/distribution/shell/src/assemble/LICENSE.bin.txt
+++ b/distribution/shell/src/assemble/LICENSE.bin.txt
@@ -391,9 +391,9 @@ The Apache Software License, Version 2.0
     - opentelemetry-context-1.56.0.jar
 
  * BookKeeper
-    - bookkeeper-common-allocator-4.17.3.jar
-    - cpu-affinity-4.17.3.jar
-    - circe-checksum-4.17.3.jar
+    - bookkeeper-common-allocator-4.17.4.0.jar
+    - cpu-affinity-4.17.4.0.jar
+    - circe-checksum-4.17.4.0.jar
   * AirCompressor
      - aircompressor-2.0.3.jar
  * AsyncHttpClient

--- a/managed-ledger/pom.xml
+++ b/managed-ledger/pom.xml
@@ -33,17 +33,17 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-server</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper.stats</groupId>
+      <groupId>${bookkeeper.groupId}.stats</groupId>
       <artifactId>prometheus-metrics-provider</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper.stats</groupId>
+      <groupId>${bookkeeper.groupId}.stats</groupId>
       <artifactId>codahale-metrics-provider</artifactId>
       <version>${bookkeeper.version}</version>
       <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,10 @@ flexible messaging model and an intuitive client API.</description>
     <!-- apache commons -->
     <commons-compress.version>1.28.0</commons-compress.version>
 
-    <bookkeeper.version>4.17.3</bookkeeper.version>
+    <storage.groupId>com.ascentstream</storage.groupId>
+    <bookkeeper.groupId>${storage.groupId}.bookkeeper</bookkeeper.groupId>
+    <distributedlog.groupId>${storage.groupId}.distributedlog</distributedlog.groupId>
+    <bookkeeper.version>4.17.4.0</bookkeeper.version>
     <zookeeper.version>3.9.5</zookeeper.version>
     <commons-cli.version>1.11.0</commons-cli.version>
     <commons-text.version>1.14.0</commons-text.version>
@@ -524,7 +527,7 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>${bookkeeper.groupId}</groupId>
         <artifactId>bookkeeper-server</artifactId>
         <version>${bookkeeper.version}</version>
         <exclusions>
@@ -557,7 +560,7 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>${bookkeeper.groupId}</groupId>
         <artifactId>cpu-affinity</artifactId>
         <version>${bookkeeper.version}</version>
       </dependency>
@@ -591,13 +594,13 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>${bookkeeper.groupId}</groupId>
         <artifactId>bookkeeper-common-allocator</artifactId>
         <version>${bookkeeper.version}</version>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>${bookkeeper.groupId}</groupId>
         <artifactId>bookkeeper-tools-framework</artifactId>
         <version>${bookkeeper.version}</version>
       </dependency>
@@ -611,7 +614,7 @@ flexible messaging model and an intuitive client API.</description>
 
       <!-- exclude the grpc version from bookkeeper and use the one defined here -->
       <dependency>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>${bookkeeper.groupId}</groupId>
         <artifactId>stream-storage-java-client</artifactId>
         <version>${bookkeeper.version}</version>
         <exclusions>
@@ -657,7 +660,7 @@ flexible messaging model and an intuitive client API.</description>
 
       <!-- exclude the grpc version from bookkeeper and use the one defined here -->
       <dependency>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>${bookkeeper.groupId}</groupId>
         <artifactId>stream-storage-server</artifactId>
         <version>${bookkeeper.version}</version>
         <exclusions>
@@ -696,19 +699,19 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper</groupId>
+        <groupId>${bookkeeper.groupId}</groupId>
         <artifactId>bookkeeper-common</artifactId>
         <version>${bookkeeper.version}</version>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper.stats</groupId>
+        <groupId>${bookkeeper.groupId}.stats</groupId>
         <artifactId>bookkeeper-stats-api</artifactId>
         <version>${bookkeeper.version}</version>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper.stats</groupId>
+        <groupId>${bookkeeper.groupId}.stats</groupId>
         <artifactId>datasketches-metrics-provider</artifactId>
         <version>${bookkeeper.version}</version>
         <exclusions>
@@ -720,7 +723,7 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.bookkeeper.stats</groupId>
+        <groupId>${bookkeeper.groupId}.stats</groupId>
         <artifactId>prometheus-metrics-provider</artifactId>
         <version>${bookkeeper.version}</version>
       </dependency>
@@ -1364,13 +1367,13 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.distributedlog</groupId>
+        <groupId>${distributedlog.groupId}</groupId>
         <artifactId>distributedlog-core</artifactId>
         <version>${bookkeeper.version}</version>
         <exclusions>
           <!-- exclude bookkeeper, reply on the bookkeeper version that pulsar uses -->
           <exclusion>
-            <groupId>org.apache.bookkeeper</groupId>
+            <groupId>${bookkeeper.groupId}</groupId>
             <artifactId>bookkeeper-server</artifactId>
           </exclusion>
           <exclusion>
@@ -1814,7 +1817,7 @@ flexible messaging model and an intuitive client API.</description>
 
     <dependency>
       <!-- We use MockedBookKeeper in many unit tests -->
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-server</artifactId>
       <version>${bookkeeper.version}</version>
       <scope>test</scope>
@@ -1848,7 +1851,7 @@ flexible messaging model and an intuitive client API.</description>
     </dependency>
     <dependency>
       <!-- We use TestStatsProvider in many unit tests -->
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-common</artifactId>
       <version>${bookkeeper.version}</version>
       <scope>test</scope>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -104,7 +104,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>stream-storage-server</artifactId>
       <exclusions>
         <exclusion>
@@ -116,7 +116,7 @@
           <artifactId>*</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.bookkeeper.tests</groupId>
+          <groupId>${bookkeeper.groupId}.tests</groupId>
           <artifactId>stream-storage-tests-common</artifactId>
         </exclusion>
         <exclusion>
@@ -131,7 +131,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-tools-framework</artifactId>
     </dependency>
 

--- a/pulsar-client-admin-shaded/pom.xml
+++ b/pulsar-client-admin-shaded/pom.xml
@@ -142,7 +142,7 @@
                   <include>javax.ws.rs:*</include>
                   <include>javax.xml.bind:jaxb-api</include>
                   <include>net.jcip:jcip-annotations</include>
-                  <include>org.apache.bookkeeper:*</include>
+                  <include>${bookkeeper.groupId}:*</include>
                   <include>org.apache.commons:commons-compress</include>
                   <include>org.apache.commons:commons-lang3</include>
                   <include>com.ascentstream.pulsar:pulsar-client-admin-original</include>

--- a/pulsar-client-all/pom.xml
+++ b/pulsar-client-all/pom.xml
@@ -191,7 +191,7 @@
                   <include>javax.xml.bind:jaxb-api</include>
                   <include>net.jcip:jcip-annotations</include>
                   <include>org.apache.avro:*</include>
-                  <include>org.apache.bookkeeper:*</include>
+                  <include>${bookkeeper.groupId}:*</include>
                   <include>org.apache.commons:commons-compress</include>
                   <include>org.apache.commons:commons-lang3</include>
                   <include>com.ascentstream.pulsar:pulsar-client-admin-original</include>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -159,7 +159,7 @@
                   <include>javax.ws.rs:*</include>
                   <include>net.jcip:jcip-annotations</include>
                   <include>org.apache.avro:*</include>
-                  <include>org.apache.bookkeeper:*</include>
+                  <include>${bookkeeper.groupId}:*</include>
                   <include>org.apache.commons:commons-compress</include>
                   <include>org.apache.commons:commons-lang3</include>
                   <!-- Issue #6834, Since Netty ByteBuf shaded, we need also shade this module -->

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -120,12 +120,12 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-common-allocator</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>cpu-affinity</artifactId>
     </dependency>
 
@@ -135,7 +135,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>circe-checksum</artifactId>
       <version>${bookkeeper.version}</version>
       <exclusions>

--- a/pulsar-functions/instance/pom.xml
+++ b/pulsar-functions/instance/pom.xml
@@ -96,7 +96,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>stream-storage-java-client</artifactId>
       <exclusions>
         <exclusion>
@@ -133,7 +133,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-common</artifactId>
       <exclusions>
         <exclusion>

--- a/pulsar-functions/localrun-shaded/pom.xml
+++ b/pulsar-functions/localrun-shaded/pom.xml
@@ -108,7 +108,7 @@
                             <artifactSet>
                                 <includes>
                                     <include>com.ascentstream.pulsar:*</include>
-                                    <include>org.apache.bookkeeper:*</include>
+                                  <include>${bookkeeper.groupId}:*</include>
                                     <include>commons-*:*</include>
                                     <include>org.apache.commons:*</include>
                                     <include>com.fasterxml.jackson.*:*</include>

--- a/pulsar-functions/worker/pom.xml
+++ b/pulsar-functions/worker/pom.xml
@@ -114,7 +114,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.distributedlog</groupId>
+      <groupId>${distributedlog.groupId}</groupId>
       <artifactId>distributedlog-core</artifactId>
       <exclusions>
         <exclusion>
@@ -125,7 +125,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-server</artifactId>
     </dependency>
 

--- a/pulsar-metadata/pom.xml
+++ b/pulsar-metadata/pom.xml
@@ -117,7 +117,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-server</artifactId>
     </dependency>
 

--- a/pulsar-package-management/bookkeeper-storage/pom.xml
+++ b/pulsar-package-management/bookkeeper-storage/pom.xml
@@ -40,7 +40,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.distributedlog</groupId>
+            <groupId>${distributedlog.groupId}</groupId>
             <artifactId>distributedlog-core</artifactId>
             <exclusions>
                 <exclusion>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -347,18 +347,18 @@
 
     <!-- Solr misdetection.
     Cannot be tied to a sha1,
-    mismatches org.apache.pulsar:pulsar-io-solr:2.10.0-SNAPSHOT
+    mismatches com.ascentstream.pulsar:pulsar-io-solr:2.10.0-SNAPSHOT
     -->
     <suppress>
         <notes><![CDATA[
-       file name: org.apache.pulsar:pulsar-io-solr:2.10.0-SNAPSHOT
+       file name: com.ascentstream.pulsar:pulsar-io-solr:2.10.0-SNAPSHOT
        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.pulsar/pulsar\-io\-solr@.*-SNAPSHOT$</packageUrl>
         <cpe>cpe:/a:apache:pulsar</cpe>
     </suppress>
     <suppress>
         <notes><![CDATA[
-       file name: org.apache.pulsar:pulsar-io-solr:2.10.0-SNAPSHOT
+       file name: com.ascentstream.pulsar:pulsar-io-solr:2.10.0-SNAPSHOT
        ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.pulsar/pulsar\-io\-solr@.*-SNAPSHOT$</packageUrl>
         <cpe>cpe:/a:apache:solr</cpe>

--- a/testmocks/pom.xml
+++ b/testmocks/pom.xml
@@ -54,7 +54,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
+      <groupId>${bookkeeper.groupId}</groupId>
       <artifactId>bookkeeper-server</artifactId>
     </dependency>
 


### PR DESCRIPTION
### Motivation

The broker currently depends on upstream BookKeeper and DistributedLog artifacts under the `org.apache.*` namespace.

To align with the internal storage distribution and simplify dependency/version management, this change migrates those dependencies to the `com.ascentstream.*` namespace.

This also improves consistency across BookKeeper and DistributedLog modules and prepares for unified storage dependency management.

### Modifications

- Migrated BookKeeper dependencies from `org.apache.*` to `com.ascentstream.*`
- Migrated DistributedLog dependencies to the `com.ascentstream.*` namespace
- Unified storage-related Maven version properties
- Updated related dependency declarations and build configuration